### PR TITLE
Changed resolve/link/unlink into GET/POST actions

### DIFF
--- a/app/controllers/api/v1x0/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/index_mixin.rb
@@ -15,8 +15,8 @@ module Api
           resp = ManageIQ::API::Common::PaginatedResponse.new(
             :base_query => filtered(scoped(base_query)),
             :request    => request,
-            :limit      => params[:limit],
-            :offset     => params[:offset]
+            :limit      => pagination_limit,
+            :offset     => pagination_offset
           ).response
 
           json_response(resp)

--- a/app/controllers/api/v1x0/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/index_mixin.rb
@@ -15,8 +15,8 @@ module Api
           resp = ManageIQ::API::Common::PaginatedResponse.new(
             :base_query => filtered(scoped(base_query)),
             :request    => request,
-            :limit      => pagination_limit,
-            :offset     => pagination_offset
+            :limit      => params[:limit],
+            :offset     => params[:offset]
           ).response
 
           json_response(resp)

--- a/app/controllers/api/v1x0/workflows_controller.rb
+++ b/app/controllers/api/v1x0/workflows_controller.rb
@@ -86,7 +86,7 @@ module Api
       end
 
       def resource_object_params
-        @resource_object_params ||= params[:resource_object].try(:to_unsafe_h) || {}
+        @resource_object_params ||= params.slice(:object_type, :object_id, :app_name).to_unsafe_h
       end
 
       def for_resource_object?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,9 +32,8 @@ Rails.application.routes.draw do
 
       resources :workflows, :only => %i(index destroy update show)
 
-      delete '/workflows/unlink', :to => "workflows#unlink", :as => 'unlink_all'
       post '/workflows/:id/link', :to => "workflows#link", :as => 'link'
-      delete '/workflows/:id/unlink', :to => "workflows#unlink", :as => 'unlink'
+      post '/workflows/:id/unlink', :to => "workflows#unlink", :as => 'unlink'
 
       resources :templates, :only => %i(index show) do
         resources :workflows, :only => %i(create index)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,10 +32,9 @@ Rails.application.routes.draw do
 
       resources :workflows, :only => %i(index destroy update show)
 
-      post '/workflows/resolve', :to => "workflows#resolve", :as => 'resolve'
-      post '/workflows/unlink', :to => "workflows#unlink", :as => 'unlink_all'
+      delete '/workflows/unlink', :to => "workflows#unlink", :as => 'unlink_all'
       post '/workflows/:id/link', :to => "workflows#link", :as => 'link'
-      post '/workflows/:id/unlink', :to => "workflows#unlink", :as => 'unlink'
+      delete '/workflows/:id/unlink', :to => "workflows#unlink", :as => 'unlink'
 
       resources :templates, :only => %i(index show) do
         resources :workflows, :only => %i(create index)

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -457,6 +457,15 @@
                 "operationId": "listWorkflows",
                 "parameters": [
                     {
+                        "$ref": "#/components/parameters/app_name"
+                    },
+                    {
+                        "$ref": "#/components/parameters/object_id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/object_type"
+                    },
+                    {
                         "$ref": "#/components/parameters/limit"
                     },
                     {
@@ -497,53 +506,8 @@
                 }
             }
         },
-        "/workflows/resolve": {
-            "post": {
-                "tags": [
-                    "Workflow"
-                ],
-                "summary": "Get all workflows linked to a resource object.",
-                "description": "Get all workflows linked to a resource object.", 
-                "operationId": "resolveWorkflows",
-                "requestBody": {
-                   "content": {
-                       "application/json": {
-                           "schema": {
-                               "$ref": "#/components/schemas/ResourceObject"
-                           }
-                       }
-                   },
-                   "description": "Resource object used to resolve workflows.",
-                   "required": true
-                },
-                "responses": {
-                   "200": {
-                       "description": "Success",
-                       "content": {
-                           "application/json": {
-                               "schema": {
-                                   "type": "array",
-                                   "items": {
-                                       "$ref": "#/components/schemas/Workflow"
-                                   }
-                               }
-                           }
-                       }
-                   },
-                   "400": {
-                       "$ref": "#/components/responses/400BadRequestResponse"
-                   },
-                   "403": {
-                       "$ref": "#/components/responses/403ForbiddenResponse"
-                   },
-                   "404": {
-                       "$ref": "#/components/responses/404NotFoundResponse"
-                   }
-                }
-            }
-        },
         "/workflows/unlink": {
-            "post": {
+            "delete": {
                 "tags": [
                   "Workflow"
                 ],
@@ -832,7 +796,7 @@
             }
         },
         "/workflows/{id}/unlink": {
-            "post": {
+            "delete": {
                 "tags": [
                   "Workflow"
                 ],
@@ -976,6 +940,33 @@
                 "explode": true,
                 "schema": {
                     "type": "object"
+                }
+            },
+            "app_name": {
+                "in": "query",
+                "name": "app_name",
+                "description": "The name of the application",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
+            },
+            "object_id": {
+                "in": "query",
+                "name": "object_id",
+                "description": "Id of the resource object",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
+            },
+            "object_type": {
+                "in": "query",
+                "name": "object_type",
+                "description": "Type of the resource object",
+                "required": false,
+                "schema": {
+                    "type": "string"
                 }
             },
             "persona": {

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -457,13 +457,7 @@
                 "operationId": "listWorkflows",
                 "parameters": [
                     {
-                        "$ref": "#/components/parameters/app_name"
-                    },
-                    {
-                        "$ref": "#/components/parameters/object_id"
-                    },
-                    {
-                        "$ref": "#/components/parameters/object_type"
+                        "$ref": "#/components/parameters/resource_object"
                     },
                     {
                         "$ref": "#/components/parameters/limit"
@@ -493,41 +487,6 @@
                                 }
                             }
                         }
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/400BadRequestResponse"
-                    },
-                    "403": {
-                        "$ref": "#/components/responses/403ForbiddenResponse"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/404NotFoundResponse"
-                    }
-                }
-            }
-        },
-        "/workflows/unlink": {
-            "delete": {
-                "tags": [
-                  "Workflow"
-                ],
-                "summary": "Break all links between a resource object and its assigned workflows",
-                "operationId": "unlinkAll",
-                "description": "Break all links between a resource object and its assigned workflows",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ResourceObject"
-                            }
-                        }
-                    },
-                    "description": "Parameters needed to remove a link",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success"
                     },
                     "400": {
                         "$ref": "#/components/responses/400BadRequestResponse"
@@ -796,7 +755,7 @@
             }
         },
         "/workflows/{id}/unlink": {
-            "delete": {
+            "post": {
                 "tags": [
                   "Workflow"
                 ],
@@ -942,31 +901,13 @@
                     "type": "object"
                 }
             },
-            "app_name": {
+            "resource_object": {
                 "in": "query",
-                "name": "app_name",
-                "description": "The name of the application",
+                "name": "resource_object",
+                "description": "The query parameters for resource object",
                 "required": false,
                 "schema": {
-                    "type": "string"
-                }
-            },
-            "object_id": {
-                "in": "query",
-                "name": "object_id",
-                "description": "Id of the resource object",
-                "required": false,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "object_type": {
-                "in": "query",
-                "name": "object_type",
-                "description": "Type of the resource object",
-                "required": false,
-                "schema": {
-                    "type": "string"
+                    "$ref": "#/components/schemas/ResourceObject"
                 }
             },
             "persona": {

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -453,11 +453,17 @@
                   "Workflow"
                 ],
                 "summary": "Return all approval workflows, only available for admin",
-                "description": "Return all approval workflows in ascending sequence order",
+                "description": "Depends on the query parameters, either return all workflows in ascending sequence order when no parameters are provided; or return the workflows linking to the resource object whose app_name, object_type and object_id are specified by query parameters",
                 "operationId": "listWorkflows",
                 "parameters": [
                     {
-                        "$ref": "#/components/parameters/resource_object"
+                        "$ref": "#/components/parameters/app_name"
+                    },
+                    {
+                        "$ref": "#/components/parameters/object_id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/object_type"
                     },
                     {
                         "$ref": "#/components/parameters/limit"
@@ -890,6 +896,33 @@
                     "default": 0
                 }
             },
+            "app_name": {
+                "name": "app_name",
+                "in": "query",
+                "description": "Name of the application",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
+            },
+            "object_id": {
+                "name": "object_id",
+                "in": "query",
+                "description": "Id of the resource object",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
+            },
+            "object_type": {
+                "name": "object_type",
+                "in": "query",
+                "description": "Type of the resource object",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
+            },
             "filter": {
                 "in": "query",
                 "name": "filter",
@@ -899,15 +932,6 @@
                 "explode": true,
                 "schema": {
                     "type": "object"
-                }
-            },
-            "resource_object": {
-                "in": "query",
-                "name": "resource_object",
-                "description": "The query parameters for resource object",
-                "required": false,
-                "schema": {
-                    "$ref": "#/components/schemas/ResourceObject"
                 }
             },
             "persona": {

--- a/spec/controllers/v1.0/workflows_controller_spec.rb
+++ b/spec/controllers/v1.0/workflows_controller_spec.rb
@@ -488,13 +488,10 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
   end
 
   # TODO: resolve needs further work to query tag names
-  describe 'GET /workflows?resource_object' do
+  describe 'GET /workflows?resource_object_params' do
     let(:obj_a) { { :object_type => 'ServiceInventory', :app_name => 'topology', :object_id => '123'} }
     let(:obj_b) { { :object_type => 'Portfolio', :app_name => 'catalog', :object_id => '123'} }
     let(:obj_c) { { :object_type => 'Portfolio', :object_id => '123'} }
-    let(:resource_object_a) { { :resource_object => obj_a } }
-    let(:resource_object_b) { { :resource_object => obj_b } }
-    let(:resource_object_c) { { :resource_object => obj_c } }
     before do
       allow(rs_class).to receive(:paginate).and_return([])
       allow(roles_obj).to receive(:roles).and_return([admin_role])
@@ -508,20 +505,20 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
     end
 
     it 'returns status code 200' do
-      get "#{api_version}/workflows", :params => resource_object_a, :headers => default_headers
+      get "#{api_version}/workflows", :params => obj_a, :headers => default_headers
 
       expect(response).to have_http_status(200)
       expect(json["data"].first["id"].to_i).to eq(id)
     end
 
     it 'returns status code 200' do
-      get "#{api_version}/workflows", :params => resource_object_b, :headers => default_headers
+      get "#{api_version}/workflows", :params => obj_b, :headers => default_headers
 
       expect(response).to have_http_status(200)
     end
 
     it 'raises an user error' do
-      get "#{api_version}/workflows", :params => resource_object_c, :headers => default_headers
+      get "#{api_version}/workflows", :params => obj_c, :headers => default_headers
 
       expect(first_error_detail).to match("Exceptions::UserError: Invalid resource object params")
       expect(response).to have_http_status(400)

--- a/spec/controllers/v1.0/workflows_controller_spec.rb
+++ b/spec/controllers/v1.0/workflows_controller_spec.rb
@@ -477,21 +477,25 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
     end
   end
 
-  describe 'POST /workflows/:id/unlink' do
+  describe 'DELETE /workflows/:id/unlink' do
     let(:obj) { { :object_type => 'inventory', :app_name => 'topology', :object_id => '123'} }
 
     it 'returns status code 204' do
-      post "#{api_version}/workflows/#{id}/unlink", :params => obj, :headers => default_headers
+      delete "#{api_version}/workflows/#{id}/unlink", :params => obj, :headers => default_headers
 
       expect(response).to have_http_status(204)
     end
   end
 
   # TODO: resolve needs further work to query tag names
-  xdescribe 'POST /workflows/resolve' do
+  describe 'GET /workflows?resource_tags' do
     let(:obj_a) { { :object_type => 'ServiceInventory', :app_name => 'topology', :object_id => '123'} }
     let(:obj_b) { { :object_type => 'Portfolio', :app_name => 'catalog', :object_id => '123'} }
+    let(:obj_c) { { :object_type => 'Portfolio', :object_id => '123'} }
     before do
+      allow(rs_class).to receive(:paginate).and_return([])
+      allow(roles_obj).to receive(:roles).and_return([admin_role])
+
       allow(AddRemoteTags).to receive(:new).with(obj_a).and_return(add_tag_svc)
       allow(add_tag_svc).to receive(:process).with(tag).and_return(add_tag_svc)
       allow(GetRemoteTags).to receive(:new).with(obj_a).and_return(get_tag_svc)
@@ -501,16 +505,23 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
     end
 
     it 'returns status code 200' do
-      post "#{api_version}/workflows/resolve", :params => obj_a, :headers => default_headers
+      get "#{api_version}/workflows", :params => obj_a, :headers => default_headers
 
       expect(response).to have_http_status(200)
-      expect(json.first["id"].to_i).to eq(id)
+      expect(json["data"].first["id"].to_i).to eq(id)
     end
 
-    it 'returns status code 204' do
-      post "#{api_version}/workflows/resolve", :params => obj_b, :headers => default_headers
+    it 'returns status code 200' do
+      get "#{api_version}/workflows", :params => obj_b, :headers => default_headers
 
-      expect(response).to have_http_status(204)
+      expect(response).to have_http_status(200)
+    end
+
+    it 'raises an user error' do
+      get "#{api_version}/workflows", :params => obj_c, :headers => default_headers
+
+      expect(response.body).to include("Exceptions::UserError: Invalid resolve params")
+      expect(response).to have_http_status(400)
     end
   end
 

--- a/spec/controllers/v1.0/workflows_controller_spec.rb
+++ b/spec/controllers/v1.0/workflows_controller_spec.rb
@@ -477,21 +477,24 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
     end
   end
 
-  describe 'DELETE /workflows/:id/unlink' do
+  describe 'POST /workflows/:id/unlink' do
     let(:obj) { { :object_type => 'inventory', :app_name => 'topology', :object_id => '123'} }
 
     it 'returns status code 204' do
-      delete "#{api_version}/workflows/#{id}/unlink", :params => obj, :headers => default_headers
+      post "#{api_version}/workflows/#{id}/unlink", :params => obj, :headers => default_headers
 
       expect(response).to have_http_status(204)
     end
   end
 
   # TODO: resolve needs further work to query tag names
-  describe 'GET /workflows?resource_tags' do
+  describe 'GET /workflows?resource_object' do
     let(:obj_a) { { :object_type => 'ServiceInventory', :app_name => 'topology', :object_id => '123'} }
     let(:obj_b) { { :object_type => 'Portfolio', :app_name => 'catalog', :object_id => '123'} }
     let(:obj_c) { { :object_type => 'Portfolio', :object_id => '123'} }
+    let(:resource_object_a) { { :resource_object => obj_a } }
+    let(:resource_object_b) { { :resource_object => obj_b } }
+    let(:resource_object_c) { { :resource_object => obj_c } }
     before do
       allow(rs_class).to receive(:paginate).and_return([])
       allow(roles_obj).to receive(:roles).and_return([admin_role])
@@ -505,22 +508,22 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
     end
 
     it 'returns status code 200' do
-      get "#{api_version}/workflows", :params => obj_a, :headers => default_headers
+      get "#{api_version}/workflows", :params => resource_object_a, :headers => default_headers
 
       expect(response).to have_http_status(200)
       expect(json["data"].first["id"].to_i).to eq(id)
     end
 
     it 'returns status code 200' do
-      get "#{api_version}/workflows", :params => obj_b, :headers => default_headers
+      get "#{api_version}/workflows", :params => resource_object_b, :headers => default_headers
 
       expect(response).to have_http_status(200)
     end
 
     it 'raises an user error' do
-      get "#{api_version}/workflows", :params => obj_c, :headers => default_headers
+      get "#{api_version}/workflows", :params => resource_object_c, :headers => default_headers
 
-      expect(response.body).to include("Exceptions::UserError: Invalid resolve params")
+      expect(first_error_detail).to match("Exceptions::UserError: Invalid resource object params")
       expect(response).to have_http_status(400)
     end
   end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -11,6 +11,10 @@ module RequestSpecHelper
     "/api/#{ver}"
   end
 
+  def first_error_detail
+    json['errors'][0]['detail']
+  end
+
   DEFAULT_USER = {
     "entitlements" => {
       "ansible"          => {


### PR DESCRIPTION
Due to the request validation, here we changed:
1. replace ` POST /workflows/resolve` with `GET /workflows?remote_object_query_params` to resolve workflows based on remote object;
2. remove `POST /workflows/unlink` with `DELETE /workflows/unlink`
