### PR TITLE
Report 403 errors from HTTP Post calls

### DIFF
--- a/app/services/remote_tagging_service.rb
+++ b/app/services/remote_tagging_service.rb
@@ -1,6 +1,6 @@
 require 'faraday'
 class RemoteTaggingService
-  VALID_200_CODES = [200, 201, 202, 204]
+  VALID_200_CODES = [200, 201, 202, 204].freeze
   def initialize(options)
     @app_name = options[:app_name]
     @object_type = options[:object_type]
@@ -72,7 +72,6 @@ class RemoteTaggingService
       raise "#{message_prefix} #{response.reason_phrase}" unless VALID_200_CODES.include?(response.status)
     end
   end
-
 
   def headers(session)
     ManageIQ::API::Common::Request.current_forwardable.each do |k, v|

--- a/app/services/remote_tagging_service.rb
+++ b/app/services/remote_tagging_service.rb
@@ -52,12 +52,7 @@ class RemoteTaggingService
       headers(session)
       session.body = tag.to_json
     end
-
-    if response.status == 403
-      raise Exceptions::NotAuthorizedError, response.reason_phrase
-    else
-      raise "Error posting tags #{response.reason_phrase}" unless response.status == 200
-    end
+    check_for_exceptions(response, "Error posting tags")
   end
 
   def get_request(url)
@@ -65,15 +60,18 @@ class RemoteTaggingService
     response = con.get(url) do |session|
       headers(session)
     end
+    check_for_exceptions(response, "Error getting tags")
+    response
+  end
 
+  def check_for_exceptions(response, message_prefix)
     if response.status == 403
       raise Exceptions::NotAuthorizedError, response.reason_phrase
     else
-      raise "Error getting tags #{response.reason_phrase}" unless response.status == 200
+      raise "#{message_prefix} #{response.reason_phrase}" unless response.status == 200
     end
-
-    response
   end
+
 
   def headers(session)
     ManageIQ::API::Common::Request.current_forwardable.each do |k, v|

--- a/app/services/remote_tagging_service.rb
+++ b/app/services/remote_tagging_service.rb
@@ -47,13 +47,17 @@ class RemoteTaggingService
 
   def post_request(url, tag)
     con = Faraday.new
-    res = con.post(url) do |session|
+    response = con.post(url) do |session|
       session.headers['Content-Type'] = 'application/json'
       headers(session)
       session.body = tag.to_json
     end
 
-    raise "Error posting tags #{res.reason_phrase}" unless res.status == 200
+    if response.status == 403
+      raise Exceptions::NotAuthorizedError, response.reason_phrase
+    else
+      raise "Error posting tags #{response.reason_phrase}" unless response.status == 200
+    end
   end
 
   def get_request(url)
@@ -61,7 +65,12 @@ class RemoteTaggingService
     response = con.get(url) do |session|
       headers(session)
     end
-    raise "Error getting tags #{response.reason_phrase}" unless response.status == 200
+
+    if response.status == 403
+      raise Exceptions::NotAuthorizedError, response.reason_phrase
+    else
+      raise "Error getting tags #{response.reason_phrase}" unless response.status == 200
+    end
 
     response
   end

--- a/app/services/remote_tagging_service.rb
+++ b/app/services/remote_tagging_service.rb
@@ -1,5 +1,6 @@
 require 'faraday'
 class RemoteTaggingService
+  VALID_200_CODES = [200, 201, 202, 204]
   def initialize(options)
     @app_name = options[:app_name]
     @object_type = options[:object_type]
@@ -68,7 +69,7 @@ class RemoteTaggingService
     if response.status == 403
       raise Exceptions::NotAuthorizedError, response.reason_phrase
     else
-      raise "#{message_prefix} #{response.reason_phrase}" unless response.status == 200
+      raise "#{message_prefix} #{response.reason_phrase}" unless VALID_200_CODES.include?(response.status)
     end
   end
 

--- a/spec/services/add_remote_tags_spec.rb
+++ b/spec/services/add_remote_tags_spec.rb
@@ -54,6 +54,15 @@ RSpec.describe AddRemoteTags, :type => :request do
         end
       end
     end
+
+    context "raises authentication error" do
+      let(:http_status) { [403, 'Authentication Error'] }
+      it 'raises an error if the status is 403' do
+        with_modified_env test_env do
+          expect { subject.process(approval_tag) }.to raise_error(Exceptions::NotAuthorizedError, /Authentication Error/)
+        end
+      end
+    end
   end
 
   context 'catalog' do


### PR DESCRIPTION
The 403 from a direct HTTP call should be converted back to a well known exception Exceptions::NotAuthorizedError so we can forward it to the UI