### PR TITLE
Set default workflow if leaf request's workflow is not set

### DIFF
--- a/app/services/request_create_service.rb
+++ b/app/services/request_create_service.rb
@@ -74,7 +74,10 @@ class RequestCreateService
 
     sub_requests = request.parent? ? request.children : [request]
 
-    sub_requests.reverse.each { |req| group_auto_approve(req, sleep_time) }
+    sub_requests.reverse.each do |req|
+      req.update!(:workflow => Workflow.default_workflow) unless req.workflow_id # each leaf must have a workflow
+      group_auto_approve(req, sleep_time)
+    end
   end
 
   def group_auto_approve(request, sleep_time)

--- a/spec/services/request_create_service_spec.rb
+++ b/spec/services/request_create_service_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe RequestCreateService do
           :requester_name => 'John Doe',
           :process_ref    => '100',
           :state          => Request::NOTIFIED_STATE,
-          :decision       => Request::UNDECIDED_STATUS
+          :decision       => Request::UNDECIDED_STATUS,
+          :workflow       => nil
         )
         [0, 1].each do |index|
           stage = request.stages[index]
@@ -47,7 +48,8 @@ RSpec.describe RequestCreateService do
             :state             => Stage::PENDING_STATE,
             :decision          => Stage::UNDECIDED_STATUS,
             :reason            => nil,
-            :random_access_key => be_kind_of(String)
+            :random_access_key => be_kind_of(String),
+            :workflow          => workflow2
           )
         end
       end
@@ -159,8 +161,12 @@ RSpec.describe RequestCreateService do
         'tags'        => [{'namespace' => 'ns1', 'name' => 'name1', 'value' => 'v1'}]
       }]
     end
+    let(:workflow) { create(:workflow) }
 
-    before { allow(Thread).to receive(:new).and_yield }
+    before do
+      allow(Thread).to receive(:new).and_yield
+      allow(Workflow).to receive(:default_workflow).and_return(workflow)
+    end
 
     it 'creates a request and auto approves' do
       expect(ContextService).to receive(:new).and_return(context_service)
@@ -175,7 +181,8 @@ RSpec.describe RequestCreateService do
         :owner          => 'jdoe',
         :state          => Request::COMPLETED_STATE,
         :decision       => Request::APPROVED_STATUS,
-        :reason         => 'System approved'
+        :reason         => 'System approved',
+        :workflow       => workflow
       )
     end
   end


### PR DESCRIPTION
Each leaf request's workflow must present for RBAC purpose. 