### PR TITLE
Cleanup generated ACLs when their associated workflow is removed

### DIFF
--- a/app/controllers/api/v1/workflows_controller.rb
+++ b/app/controllers/api/v1/workflows_controller.rb
@@ -34,14 +34,11 @@ module Api
       end
 
       def destroy
-        workflow = Workflow.find(params.require(:id))
-        workflow.destroy!
+        WorkflowDeleteService.new(params.require(:id)).delete
         head :no_content
       rescue ActiveRecord::InvalidForeignKey => e
         json_response({ :message => e.message }, :forbidden)
-      rescue ActiveRecord::RecordNotDestroyed
-        raise unless workflow.errors[:base].include?(Workflow::MSG_PROTECTED_RECORD)
-
+      rescue Exceptions::NotAuthorizedError
         json_response({ :message => Workflow::MSG_PROTECTED_RECORD }, :forbidden)
       end
 

--- a/app/services/workflow_delete_service.rb
+++ b/app/services/workflow_delete_service.rb
@@ -1,0 +1,30 @@
+class WorkflowDeleteService
+  attr_accessor :workflow
+
+  def initialize(workflow_id)
+    self.workflow = Workflow.find(workflow_id)
+  end
+
+  def delete
+    group_refs = workflow.group_refs
+
+    if group_refs.any?
+      aps = AccessProcessService.new
+
+      ContextService.new(Insights::API::Common::Request.current.to_h.transform_keys(&:to_s)).as_org_admin do
+        aps.remove_resource_from_groups(workflow.id, group_refs)
+      end
+    end
+
+    # TODO: remove remote tags
+    ##  tags = workflow.tag_links
+
+    ##  if tags.any?
+    ##    # DeleteRemoteTags.new(tags).process
+    ##  end
+
+    workflow.destroy!
+  rescue ActiveRecord::RecordNotDestroyed
+    workflow.errors[:base].include?(Workflow::MSG_PROTECTED_RECORD) ? raise(Exceptions::NotAuthorizedError, workflow.errors[:base]) : raise
+  end
+end

--- a/spec/services/workflow_delete_service_spec.rb
+++ b/spec/services/workflow_delete_service_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe WorkflowDeleteService do
+  let(:workflow) { create(:workflow, :group_refs => [990, 991]) }
+  let(:aps) { instance_double(AccessProcessService) }
+
+  subject { described_class.new(workflow.id) }
+
+  context 'when delete' do
+    before do
+      allow(AccessProcessService).to receive(:new).and_return(aps)
+      allow(aps).to receive(:remove_resource_from_groups)
+    end
+
+    it 'returns nil after deletion' do
+      Insights::API::Common::Request.with_request(RequestSpecHelper.default_request_hash) do
+        subject.delete
+
+        expect(Workflow.find_by(:id => workflow.id)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add `WorkflowDeleteService` to cleanup ACLs when workflow is destroyed.