### PR TITLE
Fix select distinct query syntax

### DIFF
--- a/app/services/workflow_find_service.rb
+++ b/app/services/workflow_find_service.rb
@@ -11,18 +11,18 @@ class WorkflowFindService
   def find_by_tag_resources(tag_resources)
     return [] if tag_resources.blank?
 
-    query = TagLink.select(:workflow_id).distinct
+    query = nil
     tag_resources.each_with_index do |tr, i|
       tag_names = tr['tags'].map { |tag| "/#{tag['namespace']}/#{tag['name']}=#{tag['value']}" }
       params = {:app_name => tr['app_name'], :object_type => tr['object_type'], :tag_name => tag_names}
       query =
         if i.zero?
-          query.where(params)
+          TagLink.where(params)
         else
           query.or(TagLink.where(params))
         end
     end
-    Workflow.where(:id => query)
+    Workflow.where(:id => query.select(:workflow_id).distinct)
   end
 
   def fq_tag_names(tag_attrs)

--- a/spec/services/workflow_find_service_spec.rb
+++ b/spec/services/workflow_find_service_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe WorkflowFindService do
       expect(workflows).to eq([workflow2, workflow1])
     end
 
+    it 'finds sorted workflow based on multiple sources' do
+      workflows = subject.find_by_tag_resources([tag_resource1, tag_resource2])
+      expect(workflows).to eq([workflow2, workflow1])
+    end
+
     it 'returns an empty array if tags are empty' do
       workflows = subject.find_by_tag_resources([tagless_resource])
       expect(workflows).to be_empty


### PR DESCRIPTION
The `select` and `distinct` keywords must be placed at the end of the query otherwise we would get error `ArgumentError (Relation passed to #or must be structurally compatible. Incompatible values: [:select, :distinct])`