### PR TITLE
Fixed to list child requests

### DIFF
--- a/app/controllers/api/v1/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1/mixins/rbac_mixin.rb
@@ -117,7 +117,7 @@ module Api
 
         # Request ids owned by requester
         def owner_request_ids
-          Request.by_owner.where(:parent_id => nil).pluck(:id).sort
+          Request.by_owner.pluck(:id).sort
         end
 
         # All child request ids for approver to process

--- a/spec/controllers/v1.0/requests_controller_spec.rb
+++ b/spec/controllers/v1.0/requests_controller_spec.rb
@@ -424,6 +424,30 @@ RSpec.describe Api::V1x0::RequestsController, :type => :request do
     end
   end
 
+  # Test suite for GET /requests/:request_id/requests
+  describe 'GET /requests/:request_id/requests' do
+    let(:parent_request) { create(:request, :name => "parent", :owner => "jdoe", :number_of_children => 2, :number_of_finished_children => 0, :tenant_id => tenant.id) }
+    let!(:child_request_a) { create(:request, :owner => "jdoe", :parent_id => parent_request.id, :name => "child a", :workflow_id => workflow.id, :tenant_id => tenant.id) }
+    let!(:child_request_b) { create(:request, :owner => "jdoe", :parent_id => parent_request.id, :name => "child b", :workflow_id => workflow.id, :tenant_id => tenant.id) }
+    let(:request_id) { parent_request.id }
+    let(:group) { double(:group, :name => "foo") }
+
+    context "Any role" do
+      before do
+        allow(Group).to receive(:find).and_return(group)
+        allow(rs_class).to receive(:paginate).and_return([])
+        allow(roles_obj).to receive(:roles).and_return([])
+      end
+
+      it 'returns status code 200' do
+        get "#{api_version}/requests/#{request_id}/requests", :headers => default_headers
+
+        expect(response).to have_http_status(200)
+        expect(json['data'].size).to eq(2)
+      end
+    end
+  end
+
   # Test suite for POST /requests
   describe 'POST /requests' do
     let(:item) { { 'disk' => '100GB' } }


### PR DESCRIPTION
For `owner` role,  current logic will filter out all sub requests by `:parent_id => nil`. Removed the filter to fix the problem.