### PR TITLE
Fix the input parameter to match the class names

### DIFF
--- a/app/services/add_remote_tags.rb
+++ b/app/services/add_remote_tags.rb
@@ -1,6 +1,6 @@
 class AddRemoteTags < RemoteTaggingService
-  def process(tag)
-    post_request(object_url, [tag])
+  def process(tags)
+    post_request(object_url, tags)
     self
   end
 

--- a/app/services/delete_remote_tags.rb
+++ b/app/services/delete_remote_tags.rb
@@ -1,6 +1,6 @@
 class DeleteRemoteTags < RemoteTaggingService
-  def process(tag)
-    post_request(object_url, [tag])
+  def process(tags)
+    post_request(object_url, tags)
     self
   end
 

--- a/app/services/workflow_link_service.rb
+++ b/app/services/workflow_link_service.rb
@@ -9,7 +9,7 @@ class WorkflowLinkService
 
   def link(tag_attrs)
     TagLink.find_or_create_by!(tag_link(tag_attrs))
-    AddRemoteTags.new(tag_attrs).process(approval_tag(workflow_id))
+    AddRemoteTags.new(tag_attrs).process([approval_tag(workflow_id)])
     nil
   end
 

--- a/app/services/workflow_unlink_service.rb
+++ b/app/services/workflow_unlink_service.rb
@@ -8,6 +8,6 @@ class WorkflowUnlinkService
   end
 
   def unlink(tag_attrs)
-    DeleteRemoteTags.new(tag_attrs).process(approval_tag(workflow_id))
+    DeleteRemoteTags.new(tag_attrs).process([approval_tag(workflow_id)])
   end
 end

--- a/spec/controllers/v1.0/workflows_controller_spec.rb
+++ b/spec/controllers/v1.0/workflows_controller_spec.rb
@@ -466,7 +466,7 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
 
     it 'returns status code 204' do
       allow(AddRemoteTags).to receive(:new).with(obj).and_return(add_tag_svc)
-      allow(add_tag_svc).to receive(:process).with(tag).and_return(add_tag_svc)
+      allow(add_tag_svc).to receive(:process).with([tag]).and_return(add_tag_svc)
       post "#{api_version}/workflows/#{id}/link", :params => obj, :headers => default_headers
 
       expect(response).to have_http_status(204)
@@ -482,7 +482,7 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
 
     it 'returns status code 204' do
       allow(DeleteRemoteTags).to receive(:new).with(obj).and_return(del_tag_svc)
-      allow(del_tag_svc).to receive(:process).with(tag).and_return(del_tag_svc)
+      allow(del_tag_svc).to receive(:process).with([tag]).and_return(del_tag_svc)
       post "#{api_version}/workflows/#{id}/unlink", :params => obj, :headers => default_headers
 
       expect(response).to have_http_status(204)
@@ -499,7 +499,7 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
       allow(roles_obj).to receive(:roles).and_return([admin_role])
 
       allow(AddRemoteTags).to receive(:new).with(obj_a).and_return(add_tag_svc)
-      allow(add_tag_svc).to receive(:process).with(tag).and_return(add_tag_svc)
+      allow(add_tag_svc).to receive(:process).with([tag]).and_return(add_tag_svc)
       allow(GetRemoteTags).to receive(:new).with(obj_a).and_return(get_tag_svc)
       allow(GetRemoteTags).to receive(:new).with(obj_b).and_return(get_tag_svc)
       allow(get_tag_svc).to receive(:process).and_return(get_tag_svc)

--- a/spec/services/add_remote_tags_spec.rb
+++ b/spec/services/add_remote_tags_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AddRemoteTags, :type => :request do
     { :tag => "/#{WorkflowLinkService::TAG_NAMESPACE}/#{WorkflowLinkService::TAG_NAME}=100" }
   end
 
-  let(:approval_tags)  { [approval_tag] }
+  let(:approval_tags) { [approval_tag] }
   let(:http_status) { [200, 'Ok'] }
   let(:headers)     do
     { 'Content-Type' => 'application/json' }.merge(default_headers)

--- a/spec/services/add_remote_tags_spec.rb
+++ b/spec/services/add_remote_tags_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe AddRemoteTags, :type => :request do
   let(:approval_tag) do
     { :tag => "/#{WorkflowLinkService::TAG_NAMESPACE}/#{WorkflowLinkService::TAG_NAME}=100" }
   end
+
+  let(:approval_tags)  { [approval_tag] }
   let(:http_status) { [200, 'Ok'] }
   let(:headers)     do
     { 'Content-Type' => 'application/json' }.merge(default_headers)
@@ -32,24 +34,24 @@ RSpec.describe AddRemoteTags, :type => :request do
   shared_examples_for '#test_all' do
     before do
       stub_request(:post, url)
-        .to_return(:status => http_status, :body => [approval_tag].to_json, :headers => headers)
+        .to_return(:status => http_status, :body => approval_tags.to_json, :headers => headers)
     end
 
     it 'adds a remote tag' do
       with_modified_env test_env do
-        subject.process(approval_tag)
+        subject.process(approval_tags)
       end
     end
 
     it 'raises an error if env is missing' do
-      expect { subject.process(approval_tag) }.to raise_error(RuntimeError, env_not_set)
+      expect { subject.process(approval_tags) }.to raise_error(RuntimeError, env_not_set)
     end
 
     context "raises error" do
       let(:http_status) { [404, 'Bad Request'] }
       it 'raises an error if the status is not 200' do
         with_modified_env test_env do
-          expect { subject.process(approval_tag) }.to raise_error(RuntimeError, /Error posting tags/)
+          expect { subject.process(approval_tags) }.to raise_error(RuntimeError, /Error posting tags/)
         end
       end
     end
@@ -58,7 +60,7 @@ RSpec.describe AddRemoteTags, :type => :request do
       let(:http_status) { [403, 'Authentication Error'] }
       it 'raises an error if the status is 403' do
         with_modified_env test_env do
-          expect { subject.process(approval_tag) }.to raise_error(Exceptions::NotAuthorizedError, /Authentication Error/)
+          expect { subject.process(approval_tags) }.to raise_error(Exceptions::NotAuthorizedError, /Authentication Error/)
         end
       end
     end

--- a/spec/services/delete_remote_tags_spec.rb
+++ b/spec/services/delete_remote_tags_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe DeleteRemoteTags, :type => :request do
   let(:approval_tag) do
     { :tag => "/#{WorkflowLinkService::TAG_NAMESPACE}/#{WorkflowLinkService::TAG_NAME}=100" }
   end
+  let(:approval_tags) { [approval_tag] }
   let(:http_status) { [200, 'Ok'] }
   let(:headers)     do
     { 'Content-Type' => 'application/json' }.merge(default_headers)
@@ -31,24 +32,24 @@ RSpec.describe DeleteRemoteTags, :type => :request do
   shared_examples_for '#test_all' do
     before do
       stub_request(:post, url)
-        .to_return(:status => http_status, :body => approval_tag.to_json, :headers => headers)
+        .to_return(:status => http_status, :body => approval_tags.to_json, :headers => headers)
     end
 
     it 'deletes a remote tag' do
       with_modified_env test_env do
-        subject.process(approval_tag)
+        subject.process(approval_tags)
       end
     end
 
     it 'raises an error if env is missing' do
-      expect { subject.process(approval_tag) }.to raise_error(RuntimeError, env_not_set)
+      expect { subject.process(approval_tags) }.to raise_error(RuntimeError, env_not_set)
     end
 
     context "raises error" do
       let(:http_status) { [404, 'Bad Request'] }
       it 'raises an error if the status is not 200' do
         with_modified_env test_env do
-          expect { subject.process(approval_tag) }.to raise_error(RuntimeError, /Error posting tags/)
+          expect { subject.process(approval_tags) }.to raise_error(RuntimeError, /Error posting tags/)
         end
       end
     end
@@ -57,7 +58,7 @@ RSpec.describe DeleteRemoteTags, :type => :request do
       let(:http_status) { [403, 'Authentication Error'] }
       it 'raises an error if the status is 403' do
         with_modified_env test_env do
-          expect { subject.process(approval_tag) }.to raise_error(Exceptions::NotAuthorizedError, /Authentication Error/)
+          expect { subject.process(approval_tags) }.to raise_error(Exceptions::NotAuthorizedError, /Authentication Error/)
         end
       end
     end

--- a/spec/services/workflow_find_service_spec.rb
+++ b/spec/services/workflow_find_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe WorkflowFindService do
   describe 'find' do
     before do
       allow(AddRemoteTags).to receive(:new).with(obj).and_return(add_tag_svc)
-      allow(add_tag_svc).to receive(:process).with(tag).and_return(add_tag_svc)
+      allow(add_tag_svc).to receive(:process).with([tag]).and_return(add_tag_svc)
       allow(GetRemoteTags).to receive(:new).with(obj).and_return(get_tag_svc)
       allow(GetRemoteTags).to receive(:new).with(another_obj).and_return(get_tag_svc)
       allow(get_tag_svc).to receive(:process).and_return(get_tag_svc)

--- a/spec/services/workflow_link_service_spec.rb
+++ b/spec/services/workflow_link_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe WorkflowLinkService, :type => :request do
   describe 'link' do
     before do
       allow(AddRemoteTags).to receive(:new).with(obj_a).and_return(remote_tag_svc)
-      allow(remote_tag_svc).to receive(:process).with(tag).and_return(remote_tag_svc)
+      allow(remote_tag_svc).to receive(:process).with([tag]).and_return(remote_tag_svc)
     end
 
     it 'adds a new link' do


### PR DESCRIPTION
In an earlier PR I missed the fact that the class name
was plural but the input parameters were singular. Fixed
input parameters so that its consistent with class name

Missed from PR https://github.com/RedHatInsights/approval-api/pull/235