### PR TITLE
Disable filtering when make GET requests to get tags.

### DIFF
--- a/app/services/get_remote_tags.rb
+++ b/app/services/get_remote_tags.rb
@@ -8,8 +8,9 @@ class GetRemoteTags < RemoteTaggingService
 
   def process
     params = {}
-    params['filter[name][eq]'] = TAG_NAME
-    params['filter[namespace][eq]'] = TAG_NAMESPACE
+    # TODO: Disabled for now since the Tag object doesn't expose these properties
+    # params['filter[name][eq]'] = TAG_NAME
+    # params['filter[namespace][eq]'] = TAG_NAMESPACE
     params['limit'] = QUERY_LIMIT
     response = get_request(object_url, params)
     @tags = JSON.parse(response.body)['data'].collect { |tag| tag['tag'] }

--- a/app/services/mixins/tag_mixin.rb
+++ b/app/services/mixins/tag_mixin.rb
@@ -9,8 +9,4 @@ module TagMixin
   def approval_tag(workflow_id)
     { 'tag' => fq_tag_name(workflow_id) }
   end
-
-  def approval_tag_filter
-    "filter[namespace][eq]=#{TAG_NAMESPACE}&filter[name][eq]=/#{TAG_NAME}"
-  end
 end

--- a/spec/services/get_remote_tags_spec.rb
+++ b/spec/services/get_remote_tags_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe GetRemoteTags, :type => :request do
   end
   let(:app_name) { 'catalog' }
   let(:object_type) { 'Portfolio' }
-  let(:url) { "http://localhost/api/catalog/v1.0/portfolios/#{object_id}/tags?filter%5Bname%5D%5Beq%5D=workflows&filter%5Bnamespace%5D%5Beq%5D=approval&limit=1000" }
+  let(:url) { "http://localhost/api/catalog/v1.0/portfolios/#{object_id}/tags?limit=1000" }
   let(:http_status) { [200, 'Ok'] }
   let(:tag1_string) { '/approval/workflows=1' }
   let(:tag2_string) { '/approval/workflows=2' }


### PR DESCRIPTION
Since tagging was re-implemented it has ony one attibute called
:tag, so its difficult to filter based on internal variables for
Tags(:namespace, :name, :value)