### PR TITLE
Fix Workflow#external_processing? and #external_signal?

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -39,11 +39,11 @@ class Workflow < ApplicationRecord
   end
 
   def external_processing?
-    template.process_setting.present?
+    template&.process_setting.present?
   end
 
   def external_signal?
-    template.signal_setting.present?
+    template&.signal_setting.present?
   end
 
   private

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -98,4 +98,23 @@ RSpec.describe Workflow, :type => :model do
       end
     end
   end
+
+  describe '#external_signal? & #external_processing?' do
+    context 'no template' do
+      it 'has no external_processing' do
+        expect(workflow.external_processing?).to be_falsey
+        expect(workflow.external_signal?).to be_falsey
+      end
+    end
+
+    context 'with template' do
+      let(:template) { create(:template, :process_setting => {'a' => 'x'}, :signal_setting => {'b' => 'y'}) }
+      let(:workflow) { create(:workflow, :template => template) }
+
+      it 'has external_processing' do
+        expect(workflow.external_processing?).to be_truthy
+        expect(workflow.external_signal?).to be_truthy
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a bug. Both method failed for `Always Approve` workflow because it does not have a template.
