### PR TITLE
openapi.json can be retrieved without credentials

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,13 +14,15 @@ class ApplicationController < ActionController::API
 
   def with_current_request
     Insights::API::Common::Request.with_request(request) do |current|
-      raise Insights::API::Common::EntitlementError, "User not Entitled" unless check_entitled(current.entitlement)
-
-      begin
+      if current.required_auth?
+        raise Insights::API::Common::EntitlementError, "User not Entitled" unless check_entitled(current.entitlement)
         ActsAsTenant.with_tenant(current_tenant(current.user)) { yield }
-      rescue Exceptions::NoTenantError
-        json_response({ :message => 'Unauthorized' }, :unauthorized)
+      else
+        ActsAsTenant.without_tenant { yield }
       end
+
+    rescue Exceptions::NoTenantError
+      json_response({ :message => 'Unauthorized' }, :unauthorized)
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,13 +16,14 @@ class ApplicationController < ActionController::API
     Insights::API::Common::Request.with_request(request) do |current|
       if current.required_auth?
         raise Insights::API::Common::EntitlementError, "User not Entitled" unless check_entitled(current.entitlement)
+
         ActsAsTenant.with_tenant(current_tenant(current.user)) { yield }
       else
         ActsAsTenant.without_tenant { yield }
       end
 
     rescue Exceptions::NoTenantError
-      json_response({ :message => 'Unauthorized' }, :unauthorized)
+      json_response({:message => 'Unauthorized'}, :unauthorized)
     end
   end
 

--- a/spec/controllers/v1.0/root_controller_spec.rb
+++ b/spec/controllers/v1.0/root_controller_spec.rb
@@ -1,18 +1,17 @@
 RSpec.describe Api::V1x0::RootController, :type => :request do
   let(:encoded_user) { encoded_user_hash }
-  let(:request_header) { { 'x-rh-identity' => encoded_user } }
   let(:api_version) { version }
 
   context "v1.0" do
     it "#openapi.json" do
-      get "#{api_version}/openapi.json", :headers => request_header
+      get "#{api_version}/openapi.json"
 
       expect(response.content_type).to eq("application/json")
       expect(response).to have_http_status(:ok)
     end
 
     it "redirects properly" do
-      get "#{api_version.split('.').first}/openapi.json", :headers => request_header
+      get "#{api_version.split('.').first}/openapi.json"
 
       expect(response.status).to eq(302)
       expect(response.headers["Location"]).to eq("#{api_version}/openapi.json")


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1145

This makes it consistent with topology, sources and catalog
There was an earlier PR https://github.com/RedHatInsights/approval-api/pull/121
which was closed without merging.