### PR TITLE
Update CMD script to only start the rails server if the migrations succeed

### DIFF
--- a/docker-assets/run_rails_server
+++ b/docker-assets/run_rails_server
@@ -10,5 +10,4 @@ KEY
 
 write_encryption_key
 
-bundle exec rake db:migrate db:seed
-bundle exec rails server
+bundle exec rake db:migrate db:seed && bundle exec rails server


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1150

Following the same thing I did on Catalog, update the CMD script so the container will only start if the datase migrations (and seeding in this case) succeed. 

Related Catalog PR: https://github.com/RedHatInsights/catalog-api/pull/563