### PR TITLE
More restrict action operation validation

### DIFF
--- a/app/controllers/api/v1/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1/mixins/rbac_mixin.rb
@@ -70,6 +70,10 @@ module Api
           assigned_roles.include?(APPROVER_ROLE)
         end
 
+        def requester?
+          !admin? && !approver?
+        end
+
         def assigned_roles
           @assigned_roles ||= Insights::API::Common::RBAC::Roles.new('approval').roles
         end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -110,7 +110,7 @@
                   "Action"
                 ],
                 "summary": "Add an action to a given request",
-                "description": "Add an action to a given request, available for admin/approver/requester. Applicable operation types are based on request current state.",
+                "description": "Add an action to a given request. Admin can do approve, deny, memo, and cancel operations; approver can do approve, deny and memo operations; while requester can do only cancel operation.",
                 "operationId": "createAction",
                 "parameters": [
                     {


### PR DESCRIPTION
Refactor the operation validation based on user's role.
Allow `notify` operation with header `x-rh-random-access-key`. This operation is not documented for public use in openapi spec. It is designed to be used as an internal call from PAM.