### PR TITLE
Add rm -rvf /root/.bundle/cache/ to Dockerfile to reduce size of image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN echo "gem: --no-document" > ~/.gemrc && \
     gem install bundler --conservative --without development:test && \
     bundle install --jobs 8 --retry 3 && \
     find $(gem env gemdir)/gems | grep "\.s\?o$" | xargs rm -rvf && \
-    rm -rvf $(gem env gemdir)/cache/*
+    rm -rvf $(gem env gemdir)/cache/* && \
+    rm -rvf /root/.bundle/cache
 
 COPY . $WORKDIR
 COPY docker-assets/entrypoint /usr/bin


### PR DESCRIPTION
Forgot to add this back in yesterday, reduces image size by 33MB.

@miq-bot add_reviewer @gmcculloug 