### PR TITLE
Sequence number must be positive

### DIFF
--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1178,11 +1178,11 @@
                 "type": "object",
                 "properties": {
                     "tag": {
-			            "example": "/namespace/architecture=x86_64",
+                        "example": "/namespace/architecture=x86_64",
                         "type": "string"
                     }
                 },
-		        "additionalProperties": false
+                "additionalProperties": false
             },
             "Request": {
                 "description": "Approval request. It may have child requests. Only a leaf node request can have workflow_id",
@@ -1336,7 +1336,9 @@
                     },
                     "sequence": {
                         "type": "integer",
-                        "description": "an indicator of the execution order for selected workflows"
+                        "description": "an indicator of the execution order for selected workflows",
+                        "minimum": 0,
+                        "exclusiveMinimum": true
                     },
                     "group_refs": {
                         "type": "array",

--- a/spec/controllers/v1.0/workflows_controller_spec.rb
+++ b/spec/controllers/v1.0/workflows_controller_spec.rb
@@ -309,22 +309,27 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
 
   # Test suite for PATCH /workflows/:id
   describe 'PATCH /workflows/:id' do
-    let(:valid_attributes) { { :name => "test", :group_refs => %w[1000] } }
+    let(:valid_attributes) { {:name => "test", :group_refs => %w[1000], :sequence => 2} }
 
     context 'admin role when item exists' do
       before do
         allow(rs_class).to receive(:paginate).and_return([])
         allow(roles_obj).to receive(:roles).and_return([admin_role])
-        patch "#{api_version}/workflows/#{id}", :params => valid_attributes, :headers => default_headers
-      end
-
-      it 'returns status code 200' do
-        expect(response).to have_http_status(200)
       end
 
       it 'updates the item' do
+        patch "#{api_version}/workflows/#{id}", :params => valid_attributes, :headers => default_headers
+
+        expect(response).to have_http_status(200)
         updated_item = Workflow.find(id)
-        expect(updated_item.group_refs).to match(["1000"])
+        expect(updated_item).to have_attributes(valid_attributes)
+      end
+
+      it 'returns status code 400 if sequence is not positive' do
+        valid_attributes[:sequence] = -1
+        patch "#{api_version}/workflows/#{id}", :params => valid_attributes, :headers => default_headers
+
+        expect(response).to have_http_status(400)
       end
     end
 


### PR DESCRIPTION
Update the open api spec to limit the sequence number to be positive. The parse automatically reinforce it and returns 400 if not conformed. 