### PR TITLE
Add /health for liveness probe

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,0 +1,3 @@
+class StatusController < ActionController::API
+  include Insights::API::Common::Status::Api
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
 
   routing_helper = Insights::API::Common::Routing.new(self)
 
+  get '/health', :to => "status#health"
+
   prefix = "api"
   if ENV["PATH_PREFIX"].present? && ENV["APP_NAME"].present?
     prefix = File.join(ENV["PATH_PREFIX"], ENV["APP_NAME"]).gsub(/^\/+|\/+$/, "")


### PR DESCRIPTION
Following the pattern created in the common gem, catalog PR for reference: https://github.com/RedHatInsights/catalog-api/pull/528/files

This will allow us to add a livenessProbe to the deployment config so the pod will auto restart if something is wrong. 