### PR TITLE
Change asset path so fonts/css load correctly

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,6 +6,10 @@ Rails.application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
+  config.public_file_server.enabled = true
+  # sets the asset path to either `/api/static` or `/api/approval/static`
+  config.assets.prefix = File.join(File::SEPARATOR, 'api', ENV['APP_NAME'].to_s, 'static')
+
   # Do not eager load code on boot.
   config.eager_load = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,9 +18,9 @@ Rails.application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
+  # sets the asset path to either `/api/static` or `/api/approval/static`
+  config.assets.prefix = File.join(File::SEPARATOR, 'api', ENV['APP_NAME'].to_s, 'static')
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
Laura reached out to me why the CSS wasn't loading from the Rails application, tried just turning on the `public_file_server` but that wasn't enough, so I changed the assets prefix as well. 

This way it generates the links in the UI for the fonts/css correctly. 