### PR TITLE
Fix time/date format and capital letters

### DIFF
--- a/app/controllers/api/v1/stageaction/show.html.erb
+++ b/app/controllers/api/v1/stageaction/show.html.erb
@@ -12,16 +12,16 @@
     <section class="pf-l-page__main-section pf-c-page__main-section">
       <section class="body" style="background-color: #fff; padding: 16px">
         <div class="pf-c-content info-panel">  
-          <h2>Catalog Request</h2>
+          <h2>Catalog request</h2>
           <p id="notice"><%= notice %></p>
           <%= render :partial => "request" %>
           <br>
-          <a href="#" onclick="showDetails()">Show Details</a>
+          <a href="#" onclick="showDetails()">Show details</a>
           <div  id="details" style="display:none;" class="pf-l-grid pf-m-gutter">
             <div class="pf-l-grid__item">
               <div class="pf-l-split pf-m-gutter">
                 <div class="pf-l-split__item install-title">
-                  Order Details
+                  Order details
                 </div>
                 <div class="pf-l-split__item pf-m-fill">
                   <% @order[:order_content].each do |k, v| %>

--- a/app/controllers/api/v1/stageaction_controller.rb
+++ b/app/controllers/api/v1/stageaction_controller.rb
@@ -79,8 +79,8 @@ module Api
           :product       => request.content["product"],
           :portfolio     => request.content["portfolio"],
           :order_id      => request.content["order_id"],
-          :order_date    => Time.zone.parse(request.created_at.to_s).strftime("%m/%d/%Y"),
-          :order_time    => Time.zone.parse(request.created_at.to_s).strftime("%I:%M %p"),
+          :order_date    => request.created_at.getutc.strftime("%d %B %Y"),
+          :order_time    => request.created_at.getutc.strftime("%H:%M UTC"),
           :order_content => request.content["params"]
         }
       end

--- a/spec/controllers/v1.0/stageaction_controller_spec.rb
+++ b/spec/controllers/v1.0/stageaction_controller_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Api::V1x0::StageactionController do
+  describe '#set_order' do
+    before { subject.instance_variable_set(:@request,  create(:request, :random_access_key => 'rand1')) }
+
+    it 'sets order date and time in correct format' do
+      order = subject.send(:set_order)
+
+      expect(order[:order_date]).to match(/\d+ [a-zA-Z]+ \d+/)
+      expect(order[:order_time]).to match(/\d+:\d+ UTC/)
+    end
+  end
+end


### PR DESCRIPTION
This is a follow-up fixes as required in #277 and #283 
<img width="405" alt="Screen Shot 2020-02-18 at 9 28 20 AM" src="https://user-images.githubusercontent.com/7047579/74744979-28d2cc00-5231-11ea-91a6-e6fdff42e0f2.png">

Before the fix:
<img width="464" alt="Screen Shot 2020-02-18 at 10 16 40 AM" src="https://user-images.githubusercontent.com/7047579/74749218-d21cc080-5237-11ea-9fcb-1256ef5c400e.png">
