### PR TITLE
Remove Always approve workflow

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -1,5 +1,5 @@
 class Workflow < ApplicationRecord
-  acts_as_tenant(:tenant, :has_global_records => true)
+  acts_as_tenant(:tenant)
 
   acts_as_list :scope => [:tenant_id], :column => 'sequence'
   default_scope { order(:sequence => :asc) }
@@ -10,29 +10,9 @@ class Workflow < ApplicationRecord
   has_many :access_control_entries, :as => :aceable, :dependent => :destroy, :inverse_of => :aceable
 
   validates :name, :presence => true
-  validate :unique_with_same_or_no_tenant
+  validate :unique_with_same_tenant
 
-  before_destroy :protect_default
-
-  MSG_PROTECTED_RECORD = "This workflow is protected from being deleted".freeze
-
-  def self.seed
-    workflow = find_or_create_by!(default_workflow_query)
-    workflow.update_attributes!(
-      :description => 'Always auto approve by system. No approvers are assigned.'
-    )
-  end
-
-  def self.default_workflow
-    @default_workflow ||= find_by(default_workflow_query)
-  end
-
-  def self.default_workflow_query
-    { :name => 'Always approve', :template => nil }
-  end
-  private_class_method :default_workflow_query
-
-  def unique_with_same_or_no_tenant
+  def unique_with_same_tenant
     if name_changed? && Workflow.exists?(:name => name)
       errors.add(:name, "has already been taken")
     end
@@ -44,14 +24,5 @@ class Workflow < ApplicationRecord
 
   def external_signal?
     template&.signal_setting.present?
-  end
-
-  private
-
-  def protect_default
-    if self.class.send(:default_workflow_query) == {:name => name, :template => template}
-      errors.add(:base, MSG_PROTECTED_RECORD)
-      throw :abort
-    end
   end
 end

--- a/app/services/request_create_service.rb
+++ b/app/services/request_create_service.rb
@@ -12,7 +12,7 @@ class RequestCreateService
       :request_context => RequestContext.new(:content => options[:content])
     )
 
-    self.workflows = WorkflowFindService.new.find_by_tag_resources(options[:tag_resources]).to_a.delete_if { |wf| wf == Workflow.default_workflow }
+    self.workflows = WorkflowFindService.new.find_by_tag_resources(options[:tag_resources]).to_a
 
     workflows.each do |workflow|
       raise Exceptions::UserError, "Workflow #{workflow.name} has no approver group" if workflow.group_refs.empty?
@@ -91,10 +91,7 @@ class RequestCreateService
 
     sub_requests = request.parent? ? request.children : [request]
 
-    sub_requests.reverse.each do |req|
-      req.update!(:workflow => Workflow.default_workflow) unless req.workflow_id # each leaf must have a workflow
-      group_auto_approve(req, sleep_time)
-    end
+    sub_requests.reverse.each { |req| group_auto_approve(req, sleep_time) }
   end
 
   def group_auto_approve(request, sleep_time)

--- a/db/migrate/20200226115345_delete_always_approve_from_workflows.rb
+++ b/db/migrate/20200226115345_delete_always_approve_from_workflows.rb
@@ -1,0 +1,13 @@
+class DeleteAlwaysApproveFromWorkflows < ActiveRecord::Migration[5.2]
+  def up
+    always_approve = Workflow.find_by(:name => 'Always approve')
+    return unless always_approve
+
+    Request.where(:workflow => always_approve).update_all(:workflow_id => nil)
+    always_approve.delete
+  end
+
+  def down
+    Workflow.create(:name => 'Always approve', :description => 'Always auto approve by system. No approvers are assigned.')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_06_182459) do
+ActiveRecord::Schema.define(version: 2020_02_26_115345) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/v1.0/graphql_controller_spec.rb
+++ b/spec/controllers/v1.0/graphql_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Api::V1x0::GraphqlController, :type => :request do
 
   let!(:template) { create(:template) }
   let(:template_id) { template.id }
-  let!(:workflows) { create_list(:workflow, 4, :template_id => template.id) }
+  let!(:workflows) { create_list(:workflow, 4, :template => template, :tenant => tenant) }
   let(:id) { workflows.first.id }
   let(:roles_obj) { instance_double(Insights::API::Common::RBAC::Roles, :roles => roles) }
 

--- a/spec/controllers/v1.0/workflows_controller_spec.rb
+++ b/spec/controllers/v1.0/workflows_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
 
   let!(:template) { create(:template) }
   let(:template_id) { template.id }
-  let!(:workflows) { create_list(:workflow, 16, :template_id => template.id) }
+  let!(:workflows) { create_list(:workflow, 16, :template => template, :tenant => tenant) }
   let(:id) { workflows.first.id }
   let(:roles_obj) { double }
   let(:add_tag_svc) { instance_double(AddRemoteTags) }
@@ -443,22 +443,6 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
       allow(roles_obj).to receive(:roles).and_return([admin_role])
       delete "#{api_version}/workflows/#{id}", :headers => default_headers
     end
-
-    it 'returns status code 403' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
-  describe 'DELETE /workflows/:id of default workflow' do
-    before do
-      allow(rs_class).to receive(:paginate).and_return([])
-      allow(roles_obj).to receive(:roles).and_return([admin_role])
-
-      Workflow.seed
-      delete "#{api_version}/workflows/#{Workflow.default_workflow.id}", :headers => default_headers
-    end
-
-    after { Workflow.instance_variable_set(:@default_workflow, nil) }
 
     it 'returns status code 403' do
       expect(response).to have_http_status(403)

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -38,23 +38,6 @@ RSpec.describe Workflow, :type => :model do
     end
   end
 
-  describe '.seed' do
-    after { Workflow.instance_variable_set(:@default_workflow, nil) }
-
-    it 'creates a default workflow' do
-      described_class.seed
-      expect(described_class.count).to be(1)
-      expect(described_class.first.template).to be_nil
-    end
-
-    it 'cannot be destroyed' do
-      described_class.seed
-      default_workflow = described_class.default_workflow
-      expect { default_workflow.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
-      expect(default_workflow.errors[:base]).to include(described_class::MSG_PROTECTED_RECORD)
-    end
-  end
-
   context "with same name in different tenants" do
     let(:another_tenant) { create(:tenant) }
     let(:another_workflow) do
@@ -78,18 +61,6 @@ RSpec.describe Workflow, :type => :model do
       before do
         ActsAsTenant.with_tenant(tenant) { workflow }
       end
-
-      it "create a workflow with same name" do
-        ActsAsTenant.with_tenant(tenant) do
-          expect { Workflow.create!(:name => workflow.name) }.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Name has already been taken')
-        end
-      end
-    end
-  end
-
-  context "with same name in no tenant" do
-    describe "create workflow" do
-      before { workflow }
 
       it "create a workflow with same name" do
         ActsAsTenant.with_tenant(tenant) do

--- a/spec/services/request_create_service_spec.rb
+++ b/spec/services/request_create_service_spec.rb
@@ -169,11 +169,6 @@ RSpec.describe RequestCreateService do
         'tags'        => [{:tag => '/ns1/name1=v1'}]
       }]
     end
-    let(:workflow) { create(:workflow) }
-
-    before do
-      allow(Workflow).to receive(:default_workflow).and_return(workflow)
-    end
 
     it 'creates a request and auto approves' do
       expect(ContextService).to receive(:new).and_return(context_service)
@@ -189,7 +184,7 @@ RSpec.describe RequestCreateService do
         :state          => Request::COMPLETED_STATE,
         :decision       => Request::APPROVED_STATUS,
         :reason         => 'System approved',
-        :workflow       => workflow,
+        :workflow       => nil,
         :group_name     => 'System approval'
       )
     end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-856. 
If no workflow is linked to any resource in an order, the default is already always approve. There is no need to ask a user to specifically choose an always approve workflow.