### PR TITLE
Move random_access_key into a separate table

### DIFF
--- a/app/controllers/api/v1/actions_controller.rb
+++ b/app/controllers/api/v1/actions_controller.rb
@@ -39,7 +39,7 @@ module Api
           admin? && ADMIN_OPERATIONS.include?(operation) ||
           approver? && APPROVER_OPERATIONS.include?(operation) ||
           requester? && REQUESTER_OPERATIONS.include?(operation) ||
-          uuid.present? && Request.find_by(:random_access_key => uuid)
+          uuid.present? && RandomAccessKey.find_by(:access_key => uuid)
 
         raise Exceptions::NotAuthorizedError, "Not authorized to create [#{operation}] action " unless valid_operation
 

--- a/app/controllers/api/v1/stageaction_controller.rb
+++ b/app/controllers/api/v1/stageaction_controller.rb
@@ -58,8 +58,9 @@ module Api
         set_view_path
         set_resources
 
-        @approver = Base64.decode64(params.require(:approver))
-        @request = Request.find_by(:random_access_key => params.require(:id))
+        access_key = RandomAccessKey.find_by(:access_key => params.require(:id))
+        @request = access_key&.request
+        @approver = access_key&.approver_name
 
         if @request
           @order = set_order

--- a/app/models/random_access_key.rb
+++ b/app/models/random_access_key.rb
@@ -1,0 +1,7 @@
+class RandomAccessKey < ApplicationRecord
+  belongs_to :request
+
+  after_initialize do |key|
+    key.access_key ||= SecureRandom.hex(16)
+  end
+end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -8,6 +8,7 @@ class Request < ApplicationRecord
   belongs_to :request_context, :optional => false
   belongs_to :workflow
   has_many :actions, -> { order(:id => :asc) }, :dependent => :destroy, :inverse_of => :request
+  has_many :random_access_keys, :dependent => :destroy, :inverse_of => :request
 
   belongs_to :parent,   :foreign_key => :parent_id, :class_name => 'Request', :inverse_of => :children
   has_many   :children, :foreign_key => :parent_id, :class_name => 'Request', :inverse_of => :parent, :dependent => :destroy

--- a/app/services/jbpm_process_service.rb
+++ b/app/services/jbpm_process_service.rb
@@ -33,10 +33,25 @@ class JbpmProcessService
       options = {
         'request'         => request,
         'request_context' => request.request_context.as_json,
-        'groups'          => [group].as_json
+        'groups'          => enhance_groups([group].as_json)
       }
     end
     options
+  end
+
+  def enhance_groups(groups_json)
+    random_access_keys = []
+    groups_json.each do |group_json|
+      group_json['users']&.each do |user_json|
+        full_name = "#{user_json['first_name']} #{user_json['last_name']}"
+        random_access_key = RandomAccessKey.new(:approver_name => full_name)
+        user_json['random_access_key'] = random_access_key.access_key
+        random_access_keys << random_access_key
+      end
+    end
+    request.random_access_keys = random_access_keys
+
+    groups_json
   end
 
   def signal_options(decision)

--- a/db/migrate/20200302143829_create_random_access_keys.rb
+++ b/db/migrate/20200302143829_create_random_access_keys.rb
@@ -1,0 +1,16 @@
+class CreateRandomAccessKeys < ActiveRecord::Migration[5.2]
+  def change
+    create_table :random_access_keys do |t|
+      t.bigint :tenant_id
+      t.bigint :request_id
+      t.string :approver_name
+      t.string :access_key
+      t.timestamps
+
+      t.index :access_key
+      t.index :tenant_id
+    end
+
+    remove_column :requests, :random_access_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_26_115345) do
+ActiveRecord::Schema.define(version: 2020_03_02_143829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,17 @@ ActiveRecord::Schema.define(version: 2020_02_26_115345) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "random_access_keys", force: :cascade do |t|
+    t.bigint "tenant_id"
+    t.bigint "request_id"
+    t.string "approver_name"
+    t.string "access_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["access_key"], name: "index_random_access_keys_on_access_key"
+    t.index ["tenant_id"], name: "index_random_access_keys_on_tenant_id"
+  end
+
   create_table "request_contexts", force: :cascade do |t|
     t.jsonb "content"
     t.jsonb "context"
@@ -67,7 +78,6 @@ ActiveRecord::Schema.define(version: 2020_02_26_115345) do
     t.string "owner"
     t.bigint "parent_id"
     t.bigint "request_context_id"
-    t.string "random_access_key"
     t.integer "number_of_children"
     t.integer "number_of_finished_children"
     t.string "group_name"
@@ -76,7 +86,6 @@ ActiveRecord::Schema.define(version: 2020_02_26_115345) do
     t.datetime "finished_at"
     t.index ["group_ref"], name: "index_requests_on_group_ref"
     t.index ["parent_id"], name: "index_requests_on_parent_id"
-    t.index ["random_access_key"], name: "index_requests_on_random_access_key"
     t.index ["tenant_id"], name: "index_requests_on_tenant_id"
     t.index ["workflow_id"], name: "index_requests_on_workflow_id"
   end

--- a/spec/controllers/v1.0/actions_controller_spec.rb
+++ b/spec/controllers/v1.0/actions_controller_spec.rb
@@ -239,11 +239,12 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
       end
 
       context 'with x-rh-random-access-key header' do
-        let!(:request) { create(:request, :with_context, :state => 'started', :tenant_id => tenant.id, :owner => "jdoe", :random_access_key => 'unique-uid') }
+        let(:random_access_key) { RandomAccessKey.new(:access_key => 'unique-uid', :approver_name => 'Joe Smith') }
+        let!(:request) { create(:request, :with_context, :state => 'started', :tenant_id => tenant.id, :owner => "jdoe", :random_access_keys => [random_access_key]) }
 
         it 'can notify a request with matched access key' do
           test_attributes = {:operation => 'notify', :processed_by => 'abcd'}
-          post "#{api_version}/requests/#{request_id}/actions", :params => test_attributes, :headers => default_headers.merge('x-rh-random-access-key' => request.random_access_key)
+          post "#{api_version}/requests/#{request_id}/actions", :params => test_attributes, :headers => default_headers.merge('x-rh-random-access-key' => random_access_key.access_key)
 
           expect(response).to have_http_status(201)
         end

--- a/spec/controllers/v1.0/stageaction_controller_spec.rb
+++ b/spec/controllers/v1.0/stageaction_controller_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Api::V1x0::StageactionController do
   describe '#set_order' do
-    before { subject.instance_variable_set(:@request,  create(:request, :random_access_key => 'rand1')) }
+    before { subject.instance_variable_set(:@request,  create(:request)) }
 
     it 'sets order date and time in correct format' do
       order = subject.send(:set_order)

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Request, type: :model do
   it { should belong_to(:parent) }
   it { should have_many(:actions) }
   it { should have_many(:children) }
+  it { should have_many(:random_access_keys) }
 
   it { should validate_presence_of(:name) }
 

--- a/spec/services/jbpm_process_service_spec.rb
+++ b/spec/services/jbpm_process_service_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe JbpmProcessService do
   end
 
   it 'starts a business process' do
+    expect(subject).to receive(:enhance_groups)
     expect(jbpm).to receive(:start_process).with('approval', 'MultiStageEmails', hash_including(:body))
     subject.start
   end
@@ -35,5 +36,30 @@ RSpec.describe JbpmProcessService do
     request.update_attributes(:process_ref => '100')
     expect(jbpm).to receive(:signal_process_instance).with('approval', '100', 'nextGroup', hash_including(:body))
     subject.signal('approved')
+  end
+
+  describe '#enhance_groups' do
+    let(:orig_groups) do
+      [{"uuid"        => "177a97e2",
+        "name"        => "Group 1",
+        "description" => "Group 1",
+        "roles"       => [],
+        "users"       =>
+          [{"username"   => "jsmith",
+            "email"      => "a@b.com",
+            "first_name" => "Joe",
+            "last_name"  => "Smith"}]
+      }]
+    end
+
+    it 'inserts random_access_key to user' do
+      allow(SecureRandom).to receive(:hex).and_return('random-access')
+
+      mod_groups = subject.send(:enhance_groups, orig_groups)
+      expect(mod_groups.first['users'].first['random_access_key']).to eq('random-access')
+
+      request.reload
+      expect(request.random_access_keys.first).to have_attributes(:access_key => 'random-access', :approver_name => 'Joe Smith')
+    end
   end
 end

--- a/spec/services/request_create_service_spec.rb
+++ b/spec/services/request_create_service_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe RequestCreateService do
             :state             => Request::STARTED_STATE,
             :decision          => Request::UNDECIDED_STATUS,
             :reason            => nil,
-            :random_access_key => be_kind_of(String),
             :workflow          => workflow2
           )
         end
@@ -76,8 +75,7 @@ RSpec.describe RequestCreateService do
           :requester_name    => 'John Doe',
           :owner             => 'jdoe',
           :state             => Request::NOTIFIED_STATE,
-          :decision          => Request::UNDECIDED_STATUS,
-          :random_access_key => be_kind_of(String)
+          :decision          => Request::UNDECIDED_STATUS
         )
       end
     end
@@ -106,7 +104,6 @@ RSpec.describe RequestCreateService do
             :state                       => Request::COMPLETED_STATE,
             :decision                    => Request::APPROVED_STATUS,
             :reason                      => 'System approved',
-
             :number_of_children          => 0,
             :number_of_finished_children => 0
           )
@@ -129,18 +126,15 @@ RSpec.describe RequestCreateService do
             :state                       => Request::COMPLETED_STATE,
             :decision                    => Request::APPROVED_STATUS,
             :reason                      => 'System approved',
-
             :number_of_children          => 3,
-            :number_of_finished_children => 3,
-            :random_access_key           => nil
+            :number_of_finished_children => 3
           )
           (0..2).each do |index|
             child = request.children[index]
             expect(child).to have_attributes(
               :state             => Request::COMPLETED_STATE,
               :decision          => Request::APPROVED_STATUS,
-              :reason            => 'System approved',
-              :random_access_key => nil
+              :reason            => 'System approved'
             )
             expect(child.actions.first).to have_attributes(
               :operation    => Action::START_OPERATION,


### PR DESCRIPTION
Each approver per request has a unique random_access_key

https://projects.engineering.redhat.com/browse/SSP-1313

Before the url looks like https://ci.cloud.redhat.com/api/approval/v1.0/stageaction/ec0150c649d9b5fbfb74439eeaaffc35?approver=Z21jY3VsbG9AcmVkaGF0LmNvbQ==

The new url looks like
https://ci.cloud.redhat.com/api/approval/v1.0/stageaction/ec0150c649d9b5fbfb74439eeaaffc35