### PR TITLE
Update request state when KIE server raises errors

### DIFF
--- a/app/services/jbpm_process_service.rb
+++ b/app/services/jbpm_process_service.rb
@@ -11,7 +11,7 @@ class JbpmProcessService
       bpm.start_process(options['container_id'], options['process_id'], :body => process_options)
     end
   rescue Exceptions::KieError => err
-    RequestUpdateService.new(request.id).update(:state => Request::FAILED_STATE, :reason => err.message, :decision => Request::ERROR_STATUS)
+    ActionCreateService.new(request.id).create(:operation => Action::ERROR_OPERATION, :processed_by => 'system', :comments => err.message)
     raise
   end
 
@@ -21,7 +21,7 @@ class JbpmProcessService
       bpm.signal_process_instance(options['container_id'], request.process_ref, options['signal_name'], :body => signal_options(decision))
     end
   rescue Exceptions::KieError => err
-    RequestUpdateService.new(request.id).update(:state => Request::FAILED_STATE, :reason => err.message, :decision => Request::ERROR_STATUS)
+    ActionCreateService.new(request.id).create(:operation => Action::ERROR_OPERATION, :processed_by => 'system', :comments => err.message)
     raise
   end
 

--- a/app/services/jbpm_process_service.rb
+++ b/app/services/jbpm_process_service.rb
@@ -10,6 +10,9 @@ class JbpmProcessService
     Kie::Service.call(KieClient::ProcessInstancesBPMApi, options) do |bpm|
       bpm.start_process(options['container_id'], options['process_id'], :body => process_options)
     end
+  rescue Exceptions::KieError => err
+    RequestUpdateService.new(request.id).update(:state => Request::FAILED_STATE, :reason => err.message, :decision => Request::ERROR_STATUS)
+    raise
   end
 
   def signal(decision)
@@ -17,6 +20,9 @@ class JbpmProcessService
     Kie::Service.call(KieClient::ProcessInstancesBPMApi, options) do |bpm|
       bpm.signal_process_instance(options['container_id'], request.process_ref, options['signal_name'], :body => signal_options(decision))
     end
+  rescue Exceptions::KieError => err
+    RequestUpdateService.new(request.id).update(:state => Request::FAILED_STATE, :reason => err.message, :decision => Request::ERROR_STATUS)
+    raise
   end
 
   private

--- a/app/services/request_update_service.rb
+++ b/app/services/request_update_service.rb
@@ -18,11 +18,11 @@ class RequestUpdateService
   private
 
   def started(options)
-    request.update!(options)
-
     if request.leaf?
       start_request
     end
+
+    request.update!(options)
 
     EventService.new(request).request_started if request.root?
 
@@ -150,6 +150,7 @@ class RequestUpdateService
 
   # complete the external approval process if configured
   def finish_request(decision)
+    return if request_completed?(decision)
     return unless request.process_ref.present? && request.workflow.try(:external_processing?)
 
     template = request.workflow.template

--- a/app/services/request_update_service.rb
+++ b/app/services/request_update_service.rb
@@ -18,11 +18,11 @@ class RequestUpdateService
   private
 
   def started(options)
+    request.update!(options)
+
     if request.leaf?
       start_request
     end
-
-    request.update!(options)
 
     EventService.new(request).request_started if request.root?
 
@@ -150,7 +150,7 @@ class RequestUpdateService
 
   # complete the external approval process if configured
   def finish_request(decision)
-    return unless request.workflow.try(:external_processing?)
+    return unless request.process_ref.present? && request.workflow.try(:external_processing?)
 
     template = request.workflow.template
     processor_class = "#{template.signal_setting['processor_type']}_process_service".classify.constantize

--- a/lib/kie/service.rb
+++ b/lib/kie/service.rb
@@ -6,7 +6,7 @@ module Kie
       yield init(klass)
     rescue KieClient::ApiError => err
       Rails.logger.error("KieClient::ApiError #{err.message} ")
-      raise Exceptions::KieError, err.message
+      raise Exceptions::KieError, "KieClient::ApiError: #{err.message}"
     end
 
     private_class_method def self.setup(options)


### PR DESCRIPTION
Update request's state to `failed` when KIE has errors.