### PR TITLE
[Stable] Check permission for both approvers and requesters

### DIFF
--- a/app/controllers/api/v1/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1/mixins/rbac_mixin.rb
@@ -52,7 +52,7 @@ module Api
         def resource_accessible?(resource, verb)
           return true if admin?
 
-          approver? ? permitted?(APPROVER_PERMISSIONS, resource, verb) : permitted?(OWNER_PERMISSIONS, resource, verb)
+          permitted?(OWNER_PERMISSIONS, resource, verb) || approver? && permitted?(APPROVER_PERMISSIONS, resource, verb)
         end
 
         # instance level check


### PR DESCRIPTION
Stable branch PR of https://github.com/RedHatInsights/approval-api/pull/299

https://projects.engineering.redhat.com/browse/SSP-1323

We need to check permission for both approvers and requesters. The permission is granted if either check passes.