### PR TITLE
Use service to service call to RBAC service where required

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 
 gem 'acts_as_list',        '~> 1.0'
 gem 'faraday',             '>= 0.17.0'
-gem 'insights-api-common', '~> 3.6'
+gem 'insights-api-common', '~> 3.8'
 gem 'jbuilder',            '~> 2.0'
 gem 'manageiq-loggers',    '~> 0.2'
 gem 'manageiq-messaging',  '~> 0.1'

--- a/app/controllers/api/v1x0/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/rbac_mixin.rb
@@ -134,7 +134,7 @@ module Api
         end
 
         def assigned_group_refs
-          Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
+          Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi, Thread.current[:rbac_extra_headers] || {}) do |api|
             Insights::API::Common::RBAC::Service.paginate(api, :list_groups, :scope => 'principal').collect(&:uuid)
           end
         end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -7,7 +7,7 @@ class Group
 
   def self.find(uuid)
     group = nil
-    Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
+    Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi, Thread.current[:rbac_extra_headers] || {}) do |api|
       group = from_raw(api.get_group(uuid))
     end
     group
@@ -15,7 +15,7 @@ class Group
 
   def self.all(username = nil)
     groups = []
-    Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
+    Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi, Thread.current[:rbac_extra_headers] || {}) do |api|
       Insights::API::Common::RBAC::Service.paginate(api, :list_groups, :username => username).each do |item|
         groups << from_raw(item)
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User
 
   def self.find_by_username(username)
     user = nil
-    Insights::API::Common::RBAC::Service.call(RBACApiClient::PrincipalApi) do |api|
+    Insights::API::Common::RBAC::Service.call(RBACApiClient::PrincipalApi, Thread.current[:rbac_extra_headers] || {}) do |api|
       user = from_raw(api.get_principal(username))
     end
     user
@@ -19,7 +19,7 @@ class User
 
   def self.all
     users = []
-    Insights::API::Common::RBAC::Service.call(RBACApiClient::PrincipalApi) do |api|
+    Insights::API::Common::RBAC::Service.call(RBACApiClient::PrincipalApi, Thread.current[:rbac_extra_headers] || {}) do |api|
       Insights::API::Common::RBAC::Service.paginate(api, :list_principals, {}).each do |item|
         users << from_raw(item)
       end

--- a/spec/controllers/v1.0/actions_controller_spec.rb
+++ b/spec/controllers/v1.0/actions_controller_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
 
   before do
     allow(Insights::API::Common::RBAC::Roles).to receive(:new).and_return(roles_obj)
-    allow(rs_class).to receive(:call).with(RBACApiClient::AccessApi).and_yield(api_instance)
-    allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
+    allow(rs_class).to receive(:call).with(RBACApiClient::AccessApi, {}).and_yield(api_instance)
+    allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi, {}).and_yield(api_instance)
   end
 
   describe 'GET /actions/:id' do

--- a/spec/controllers/v1.0/requests_controller_spec.rb
+++ b/spec/controllers/v1.0/requests_controller_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Api::V1x0::RequestsController, :type => :request do
   before do
     allow(WorkflowFindService).to receive(:new).and_return(workflow_find_service)
     allow(Insights::API::Common::RBAC::Roles).to receive(:new).and_return(roles_obj)
-    allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
+    allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi, {}).and_yield(api_instance)
   end
 
   describe 'GET /requests (for admin persona)' do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Group do
       raw_group = double(:raw_group, :uuid => 'uuid', :description => 'desc', :name => 'gname', :principals => %w[u1 u2])
       group_api = double(:group_api)
       expect(group_api).to receive(:get_group).with('uuid').and_return(raw_group)
-      expect(Insights::API::Common::RBAC::Service).to receive(:call).with(RBACApiClient::GroupApi).and_yield(group_api)
+      expect(Insights::API::Common::RBAC::Service).to receive(:call).with(RBACApiClient::GroupApi, {}).and_yield(group_api)
     end
 
     it 'fetches a group with details from rbac service' do
@@ -23,7 +23,7 @@ RSpec.describe Group do
       raw_list = double(:group_list, :meta => double(:count => 2), :data => raw_groups)
       group_api = double(:group_api)
       expect(group_api).to receive(:list_groups).with(hash_including(:username => 'myname')).and_return(raw_list)
-      expect(Insights::API::Common::RBAC::Service).to receive(:call).with(RBACApiClient::GroupApi).and_yield(group_api)
+      expect(Insights::API::Common::RBAC::Service).to receive(:call).with(RBACApiClient::GroupApi, {}).and_yield(group_api)
     end
 
     it 'list all groups' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe User do
       raw_user = double(:raw_user, :username => 'myname', :email => 'a@b', :first_name => 'First', :last_name => 'Last', :is_org_admin => true)
       user_api = double(:user_api)
       expect(user_api).to receive(:get_principal).with('myname').and_return(raw_user)
-      expect(Insights::API::Common::RBAC::Service).to receive(:call).with(RBACApiClient::PrincipalApi).and_yield(user_api)
+      expect(Insights::API::Common::RBAC::Service).to receive(:call).with(RBACApiClient::PrincipalApi, {}).and_yield(user_api)
     end
 
     it 'fetches a group with details from rbac service' do


### PR DESCRIPTION
Refactor `ContentService#act_as_org_admin` method wherever we need to call RBAC with org_admin right to use the newly supported service_to_service call feature from RBAC team.

Wait for a new `insights-api-common` gem release that include https://github.com/RedHatInsights/insights-api-common-rails/pull/168.