### PR TITLE
Allow for major version redirects to work for root_controller

### DIFF
--- a/app/controllers/api/v1.rb
+++ b/app/controllers/api/v1.rb
@@ -1,4 +1,9 @@
 module Api
   module V1
+    class RootController < ApplicationController
+      def openapi
+        render :json => Api::Docs["1.0"]
+      end
+    end
   end
 end

--- a/app/controllers/api/v1/root_controller.rb
+++ b/app/controllers/api/v1/root_controller.rb
@@ -1,9 +1,0 @@
-module Api
-  module V1
-    class RootController < ApplicationController
-      def openapi
-        render :json => Api::Docs["1.0"]
-      end
-    end
-  end
-end

--- a/app/controllers/api/v1x0.rb
+++ b/app/controllers/api/v1x0.rb
@@ -1,8 +1,12 @@
 module Api
   module V1x0
+    class RootController < ApplicationController
+      def openapi
+        render :json => Api::Docs["1.0"]
+      end
+    end
     class ActionsController     < Api::V1::ActionsController; end
     class RequestsController    < Api::V1::RequestsController; end
-    class RootController        < Api::V1::RootController; end
     class StageactionController < Api::V1::StageactionController; end
     class TemplatesController   < Api::V1::TemplatesController; end
     class WorkflowsController   < Api::V1::WorkflowsController; end

--- a/app/controllers/api/v1x1.rb
+++ b/app/controllers/api/v1x1.rb
@@ -1,8 +1,12 @@
 module Api
   module V1x1
+    class RootController < ApplicationController
+      def openapi
+        render :json => Api::Docs["1.1"]
+      end
+    end
     class ActionsController     < Api::V1::ActionsController; end
     class RequestsController    < Api::V1::RequestsController; end
-    class RootController        < Api::V1::RootController; end
     class StageactionController < Api::V1::StageactionController; end
     class TemplatesController   < Api::V1::TemplatesController; end
     class WorkflowsController   < Api::V1::WorkflowsController; end


### PR DESCRIPTION
This allows for `/v1/openapi.json` to redirect to the latest minor version `v1.1`

Also fixes an issue where `/v1.1/openapi.json` was returning a 400.

Below are examples of the api requests and their subsequent log entries:
```
curl localhost:3000/api/v1.1/openapi.json

[----] I, [2020-03-18T13:39:21.993990 #91634:3fdb98032e98]  INFO -- : Started GET "/api/v1.1/openapi.json" for ::1 at 2020-03-18 13:39:21 -0400
[----] I, [2020-03-18T13:39:22.058501 #91634:3fdb98032e98]  INFO -- : Processing by Api::V1x1::RootController#openapi as */*
[----] I, [2020-03-18T13:39:22.058770 #91634:3fdb98032e98]  INFO -- : Request started http://localhost:3000/api/v1.1/openapi.json
[----] I, [2020-03-18T13:39:22.068380 #91634:3fdb98032e98]  INFO -- : Request ended http://localhost:3000/api/v1.1/openapi.json
[----] I, [2020-03-18T13:39:22.068585 #91634:3fdb98032e98]  INFO -- : Completed 200 OK in 10ms (Views: 5.6ms | ActiveRecord: 0.0ms)

curl localhost:3000/api/v1.0/openapi.json

[----] I, [2020-03-18T13:40:21.579903 #91634:3fdb98032e0c]  INFO -- : Started GET "/api/v1.0/openapi.json" for ::1 at 2020-03-18 13:40:21 -0400
[----] I, [2020-03-18T13:40:21.608075 #91634:3fdb98032e0c]  INFO -- : Processing by Api::V1x0::RootController#openapi as */*
[----] I, [2020-03-18T13:40:21.608311 #91634:3fdb98032e0c]  INFO -- : Request started http://localhost:3000/api/v1.0/openapi.json
[----] I, [2020-03-18T13:40:21.614238 #91634:3fdb98032e0c]  INFO -- : Request ended http://localhost:3000/api/v1.0/openapi.json
[----] I, [2020-03-18T13:40:21.614425 #91634:3fdb98032e0c]  INFO -- : Completed 200 OK in 6ms (Views: 5.7ms | ActiveRecord: 0.0ms)

curl -L localhost:3000/api/v1/openapi.json

[----] I, [2020-03-18T13:41:32.936119 #91634:3fdb98032d80]  INFO -- : Started GET "/api/v1/openapi.json" for ::1 at 2020-03-18 13:41:32 -0400
[----] I, [2020-03-18T13:41:32.954490 #91634:3fdb98032d80]  INFO -- : Started GET "/api/v1.1/openapi.json" for ::1 at 2020-03-18 13:41:32 -0400
[----] I, [2020-03-18T13:41:32.963887 #91634:3fdb98032d80]  INFO -- : Processing by Api::V1x1::RootController#openapi as */*
[----] I, [2020-03-18T13:41:32.964116 #91634:3fdb98032d80]  INFO -- : Request started http://localhost:3000/api/v1.1/openapi.json
[----] I, [2020-03-18T13:41:32.970811 #91634:3fdb98032d80]  INFO -- : Request ended http://localhost:3000/api/v1.1/openapi.json
[----] I, [2020-03-18T13:41:32.971027 #91634:3fdb98032d80]  INFO -- : Completed 200 OK in 7ms (Views: 6.1ms | ActiveRecord: 0.0ms)
```

JIRA: https://projects.engineering.redhat.com/browse/SSP-1318