### PR TITLE
Add the correct inherited graphql version into the v1.1 version module

### DIFF
--- a/app/controllers/api/v1x1.rb
+++ b/app/controllers/api/v1x1.rb
@@ -6,6 +6,7 @@ module Api
       end
     end
     class ActionsController     < Api::V1::ActionsController; end
+    class GraphqlController     < Api::V1x0::GraphqlController; end
     class RequestsController    < Api::V1::RequestsController; end
     class StageactionController < Api::V1::StageactionController; end
     class TemplatesController   < Api::V1::TemplatesController; end


### PR DESCRIPTION
Adds the missing v1x0 reference to `GraphQLController` in the `v1x1` version module.

BEFORE: ( on CI )

```
curl -u user:password -X POST https://ci.cloud.redhat.com/api/approval/v1.1/graphql
<!DOCTYPE html>
<html>
<head>
  <title>The page you were looking for doesn't exist (404)</title>
  <meta name="viewport" content="width=device-width,initial-scale=1">
  <style>
  body {
    background-color: #EFEFEF;
    color: #2E2F30;
    text-align: center;
    font-family: arial, sans-serif;
    margin: 0;
  }
```

AFTER: ( local changes )
```
curl -X POST localhost:3000/api/v1.1/graphql/                                                               
{"errors":[{"status":400,"detail":"OpenAPIParser::NotExistRequiredKey: #/components/schemas/GraphqlIn missing required parameters: query"}]}
```

JIRA: https://projects.engineering.redhat.com/browse/SSP-1361