### PR TITLE
API /requests lists child requests visible to approver

### DIFF
--- a/app/controllers/api/v1x0/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/rbac_mixin.rb
@@ -6,6 +6,7 @@ module Api
 
         ADMIN_ROLE = 'Approval Administrator'.freeze
         APPROVER_ROLE = 'Approval Approver'.freeze
+        APPROVER_VISIBLE_STATES = [ApprovalStates::NOTIFIED_STATE, ApprovalStates::COMPLETED_STATE].freeze
 
         # create action only needs class level permission check
         def create_access_check
@@ -129,19 +130,13 @@ module Api
 
         # All child request ids for approver to process
         def visible_request_ids_for_approver
-          visible_states = [ApprovalStates::NOTIFIED_STATE, ApprovalStates::COMPLETED_STATE]
-          Request.where(:workflow_id => workflow_ids, :state => visible_states).pluck(:id)
+          Request.where(:group_ref => assigned_group_refs, :state => APPROVER_VISIBLE_STATES).pluck(:id)
         end
 
         def assigned_group_refs
           Insights::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
             Insights::API::Common::RBAC::Service.paginate(api, :list_groups, :scope => 'principal').collect(&:uuid)
           end
-        end
-
-        # The accessible workflow ids for approver
-        def workflow_ids
-          AccessControlEntry.where(:aceable_type => 'Workflow', :permission => 'approve', :group_uuid => assigned_group_refs).pluck(:aceable_id)
         end
       end
     end

--- a/spec/controllers/v1.0/actions_controller_spec.rb
+++ b/spec/controllers/v1.0/actions_controller_spec.rb
@@ -2,27 +2,22 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
   include_context "approval_rbac_objects"
   let(:tenant) { create(:tenant) }
 
-  let!(:template) { create(:template) }
-  let!(:workflow) { create(:workflow, :template_id => template.id, :tenant_id => tenant.id) }
-  let!(:group_ref) { "990" }
-  let(:group) { instance_double(Group, :name => 'group1', :uuid => group_ref) }
-  let!(:request) { create(:request, :with_context, :workflow_id => workflow.id, :group_ref => group_ref, :state => 'notified', :tenant_id => tenant.id, :owner => "jdoe") }
-  let!(:request_id) { request.id }
+  let(:template) { create(:template) }
+  let(:workflow) { create(:workflow, :template => template, :tenant => tenant) }
 
-  let!(:actions) { create_list(:action, 10, :request_id => request.id, :tenant_id => tenant.id) }
+  let(:group) { instance_double(Group, :name => 'group1', :uuid => 'ref1') }
+  let(:request) { create(:request, :with_context, :workflow => workflow, :group_ref => group.uuid, :state => 'notified', :tenant => tenant, :owner => "jdoe") }
+  let(:actions) { create_list(:action, 10, :request => request, :tenant => tenant) }
   let(:id) { actions.first.id }
 
-  let(:roles_obj) { double }
+  let(:group2) { instance_double(Group, :name => 'group2', :uuid => 'ref2') }
+  let(:request2) { create(:request, :with_context, :workflow => workflow, :group_ref => group2.uuid, :state => 'notified', :tenant => tenant, :owner => "jdoe") }
+  let(:actions2) { create_list(:action, 10, :request => request2, :tenant => tenant) }
+  let(:id2) { actions2.first.id }
 
-  let(:setup_approver_role_with_acls) do
-    aces = [AccessControlEntry.new(:permission => 'approve', :group_uuid => group_ref, :tenant_id => tenant.id)]
+  let(:roles_obj) { instance_double(Insights::API::Common::RBAC::Roles) }
 
-    workflow.update!(:access_control_entries => aces)
-    allow(rs_class).to receive(:paginate).and_return([group])
-    allow(roles_obj).to receive(:roles).and_return([approver_role])
-  end
-
-  let(:setup_approver_role_without_acls) do
+  let(:setup_approver_role) do
     allow(rs_class).to receive(:paginate).and_return([group])
     allow(roles_obj).to receive(:roles).and_return([approver_role])
   end
@@ -76,21 +71,20 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
     end
 
     context 'approver role' do
-      before { setup_approver_role_with_acls }
+      before { setup_approver_role }
 
       context 'when approver can read' do
         it 'returns status code 200' do
           get "#{api_version}/actions/#{id}", :headers => default_headers
 
+          expect(json['id']).to eq(id.to_s)
           expect(response).to have_http_status(200)
         end
       end
 
       context 'when approver cannot read' do
         it 'returns status code 403' do
-          AccessControlEntry.first.update(:group_uuid => 'abc')
-
-          get "#{api_version}/actions/#{id}", :headers => default_headers
+          get "#{api_version}/actions/#{id2}", :headers => default_headers
 
           expect(response).to have_http_status(403)
         end
@@ -112,10 +106,13 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
 
   describe "GET /requests/:request_id/actions" do
     context 'admin role when request attributes are valid' do
-      before { setup_admin_role }
+      before do
+        id
+        setup_admin_role
+      end
 
       it 'returns the actions' do
-        get "#{api_version}/requests/#{request_id}/actions", :headers => default_headers
+        get "#{api_version}/requests/#{request.id}/actions", :headers => default_headers
 
         expect(json['links']).not_to be_nil
         expect(json['links']['first']).to match(/offset=0/)
@@ -125,35 +122,42 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
       end
     end
 
-    context 'approver role can get actions' do
-      before { setup_approver_role_with_acls }
+    context 'approver role' do
+      before { setup_approver_role}
 
-      it 'returns the actions' do
-        get "#{api_version}/requests/#{request_id}/actions", :headers => default_headers
+      context 'approver can read actions' do
+        before { id }
 
-        expect(json['links']).not_to be_nil
-        expect(json['links']['first']).to match(/offset=0/)
-        expect(json['data'].size).to eq(10)
+        it 'returns the actions' do
+          get "#{api_version}/requests/#{request.id}/actions", :headers => default_headers
 
-        expect(response).to have_http_status(200)
+          expect(json['links']).not_to be_nil
+          expect(json['links']['first']).to match(/offset=0/)
+          expect(json['data'].size).to eq(10)
+
+          expect(response).to have_http_status(200)
+        end
       end
-    end
 
-    context 'approver role cannot get actions' do
-      before { setup_approver_role_without_acls }
+      context 'approver cannot get actions' do
+        before { id2 }
 
-      it 'returns status code 403' do
-        get "#{api_version}/requests/#{request_id}/actions", :headers => default_headers
+        it 'returns status code 403' do
+          get "#{api_version}/requests/#{request2.id}/actions", :headers => default_headers
 
-        expect(response).to have_http_status(403)
+          expect(response).to have_http_status(403)
+        end
       end
     end
 
     context 'requester role cannot get actions' do
-      before { setup_requester_role }
+      before do
+        id
+        setup_requester_role
+      end
 
       it 'returns status code 403' do
-        get "#{api_version}/requests/#{request_id}/actions", :headers => default_headers
+        get "#{api_version}/requests/#{request.id}/actions", :headers => default_headers
 
         expect(response).to have_http_status(403)
       end
@@ -166,14 +170,14 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
 
       it 'can add valid operation' do
         test_attributes = {:operation => 'cancel', :processed_by => 'abcd'}
-        post "#{api_version}/requests/#{request_id}/actions", :params => test_attributes, :headers => default_headers
+        post "#{api_version}/requests/#{request.id}/actions", :params => test_attributes, :headers => default_headers
 
         expect(response).to have_http_status(201)
       end
 
       it 'cannot add invalid operation' do
         test_attributes = {:operation => 'bad-op', :processed_by => 'abcd'}
-        post "#{api_version}/requests/#{request_id}/actions", :params => test_attributes, :headers => default_headers
+        post "#{api_version}/requests/#{request.id}/actions", :params => test_attributes, :headers => default_headers
 
         expect(response).to have_http_status(400)
       end
@@ -181,7 +185,7 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
       it 'cannot add unauthorized operation' do
         ['start', 'notify', 'skip'].each do |op|
           test_attributes = {:operation => op, :processed_by => 'abcd'}
-          post "#{api_version}/requests/#{request_id}/actions", :params => test_attributes, :headers => default_headers
+          post "#{api_version}/requests/#{request.id}/actions", :params => test_attributes, :headers => default_headers
 
           expect(response).to have_http_status(403)
         end
@@ -189,11 +193,11 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
     end
 
     context 'approver role for assigned request' do
-      before { setup_approver_role_with_acls }
+      before { setup_approver_role }
 
       it 'can approve a request' do
         test_attributes = {:operation => 'approve', :processed_by => 'abcd'}
-        post "#{api_version}/requests/#{request_id}/actions", :params => test_attributes, :headers => default_headers
+        post "#{api_version}/requests/#{request.id}/actions", :params => test_attributes, :headers => default_headers
 
         expect(response).to have_http_status(201)
       end
@@ -201,7 +205,7 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
       it 'cannot add unauthorized operation' do
         ['start', 'notify', 'skip', 'cancel'].each do |op|
           test_attributes = {:operation => op, :processed_by => 'abcd'}
-          post "#{api_version}/requests/#{request_id}/actions", :params => test_attributes, :headers => default_headers
+          post "#{api_version}/requests/#{request.id}/actions", :params => test_attributes, :headers => default_headers
 
           expect(response).to have_http_status(403)
         end
@@ -209,11 +213,11 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
     end
 
     context 'approver role for unassigned request' do
-      before { setup_approver_role_without_acls }
+      before { setup_approver_role }
 
       it 'cannot approve a request' do
         test_attributes = {:operation => 'approve', :processed_by => 'abcd'}
-        post "#{api_version}/requests/#{request_id}/actions", :params => test_attributes, :headers => default_headers
+        post "#{api_version}/requests/#{request2.id}/actions", :params => test_attributes, :headers => default_headers
 
         expect(response).to have_http_status(403)
       end
@@ -225,7 +229,7 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
       it 'cannot add unauthorized operation' do
         ['start', 'notify', 'skip', 'approve', 'deny'].each do |op|
           test_attributes = {:operation => op, :processed_by => 'abcd'}
-          post "#{api_version}/requests/#{request_id}/actions", :params => test_attributes, :headers => default_headers
+          post "#{api_version}/requests/#{request.id}/actions", :params => test_attributes, :headers => default_headers
 
           expect(response).to have_http_status(403)
         end
@@ -233,7 +237,7 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
 
       it 'can cancel a request' do
         test_attributes = {:operation => 'cancel', :processed_by => 'abcd'}
-        post "#{api_version}/requests/#{request_id}/actions", :params => test_attributes, :headers => default_headers
+        post "#{api_version}/requests/#{request.id}/actions", :params => test_attributes, :headers => default_headers
 
         expect(response).to have_http_status(201)
       end
@@ -244,7 +248,7 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
 
         it 'can notify a request with matched access key' do
           test_attributes = {:operation => 'notify', :processed_by => 'abcd'}
-          post "#{api_version}/requests/#{request_id}/actions", :params => test_attributes, :headers => default_headers.merge('x-rh-random-access-key' => random_access_key.access_key)
+          post "#{api_version}/requests/#{request.id}/actions", :params => test_attributes, :headers => default_headers.merge('x-rh-random-access-key' => random_access_key.access_key)
 
           expect(response).to have_http_status(201)
         end


### PR DESCRIPTION
 https://projects.engineering.redhat.com/browse/SSP-1370

Before for endpoint `/requests` the controller always limits the collection to parent requests where `:parent_id => nil` and continues to narrow the collection according to persona. However approvers can see never see parent requests but only qualified children.

With this fix the endpoint now includes child requests that approvers can see.

Also we discover that `access_control_entries` are no longer needed because each child request has `group_ref` attribute to filter approvers and `owner` attribute to filter requesters. 

A follow-up PR will completely remove `access_control_entries` table.