### PR TITLE
Enabled user capabilities in Approval

### DIFF
--- a/app/controllers/api/v1x0/actions_controller.rb
+++ b/app/controllers/api/v1x0/actions_controller.rb
@@ -5,8 +5,6 @@ module Api
 
       def index
         req = Request.find(params.require(:request_id))
-        authorize req, :show?
-
         collection(policy_scope(req.actions))
       end
 

--- a/app/controllers/api/v1x0/actions_controller.rb
+++ b/app/controllers/api/v1x0/actions_controller.rb
@@ -4,8 +4,7 @@ module Api
       include Mixins::IndexMixin
 
       def index
-        req = Request.find(params.require(:request_id))
-        collection(policy_scope(req.actions))
+        collection(policy_scope(Action))
       end
 
       def show

--- a/app/controllers/api/v1x0/graphql_controller.rb
+++ b/app/controllers/api/v1x0/graphql_controller.rb
@@ -17,7 +17,7 @@ module Api
         {
           "^.*$" => {
             "base_query" => lambda do |model_class, _ctx|
-              policy_scope(model_class.all)
+              policy_scope(model_class)
             end
           }
         }

--- a/app/controllers/api/v1x0/graphql_controller.rb
+++ b/app/controllers/api/v1x0/graphql_controller.rb
@@ -17,7 +17,7 @@ module Api
         {
           "^.*$" => {
             "base_query" => lambda do |model_class, _ctx|
-              policy_scope(model_class)
+              policy_scope(model_class.all)
             end
           }
         }

--- a/app/controllers/api/v1x0/requests_controller.rb
+++ b/app/controllers/api/v1x0/requests_controller.rb
@@ -21,7 +21,7 @@ module Api
         relation = if params[:request_id]
                      Request.find(params.require(:request_id)).children
                    else
-                     Request.all
+                     Request
                    end
 
         collection(policy_scope(relation))

--- a/app/controllers/api/v1x0/requests_controller.rb
+++ b/app/controllers/api/v1x0/requests_controller.rb
@@ -19,11 +19,9 @@ module Api
 
       def index
         relation = if params[:request_id]
-                     req = Request.find(params.require(:request_id))
-                     authorize req, :show?
-                     req.children
+                     Request.find(params.require(:request_id)).children
                    else
-                     Request
+                     Request.all
                    end
 
         collection(policy_scope(relation))

--- a/app/controllers/api/v1x0/requests_controller.rb
+++ b/app/controllers/api/v1x0/requests_controller.rb
@@ -18,13 +18,7 @@ module Api
       end
 
       def index
-        relation = if params[:request_id]
-                     Request.find(params.require(:request_id)).children
-                   else
-                     Request
-                   end
-
-        collection(policy_scope(relation))
+        collection(policy_scope(Request))
       end
    end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,19 +17,17 @@ class ApplicationController < ActionController::API
     Insights::API::Common::Request.with_request(request) do |current|
       Rails.logger.info("Request started #{request.original_url}")
 
-      if current.required_auth?
-        raise Insights::API::Common::EntitlementError, "User not Entitled" unless check_entitled(current.entitlement)
+      UserContext.with_user_context(UserContext.new(current, params)) do |user_context|
+        if current.required_auth?
+          raise Insights::API::Common::EntitlementError, "User not Entitled" unless check_entitled(current.entitlement)
 
-        Thread.current[:user] = UserContext.new(request, params)
-        ActsAsTenant.with_tenant(current_tenant(current)) { yield.tap { Rails.logger.info("Request ended #{request.original_url}") } }
-      else
-        ActsAsTenant.without_tenant { yield.tap {Rails.logger.info("Request ended #{request.original_url}")} }
+          ActsAsTenant.with_tenant(current_tenant(current)) { yield.tap { Rails.logger.info("Request ended #{request.original_url}") } }
+        else
+          ActsAsTenant.without_tenant { yield.tap {Rails.logger.info("Request ended #{request.original_url}")} }
+        end
       end
-
     rescue Exceptions::NoTenantError
       json_response({:message => 'Unauthorized'}, :unauthorized)
-    ensure
-      Thread.current[:user] = nil
     end
   end
 
@@ -46,6 +44,6 @@ class ApplicationController < ActionController::API
   end
 
   def pundit_user
-    Thread.current[:user]
+    UserContext.current_user_context
   end
 end

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -11,6 +11,10 @@ class Action < ApplicationRecord
   ERROR_OPERATION   = 'error'.freeze
   OPERATIONS = [START_OPERATION, NOTIFY_OPERATION, SKIP_OPERATION, MEMO_OPERATION, APPROVE_OPERATION, DENY_OPERATION, CANCEL_OPERATION, ERROR_OPERATION].freeze
 
+  ADMIN_OPERATIONS     = [MEMO_OPERATION, APPROVE_OPERATION, DENY_OPERATION, CANCEL_OPERATION].freeze
+  APPROVER_OPERATIONS  = [MEMO_OPERATION, APPROVE_OPERATION, DENY_OPERATION].freeze
+  REQUESTER_OPERATIONS = [CANCEL_OPERATION].freeze
+
   validates :operation, :inclusion => { :in => OPERATIONS }
   validates :processed_by, :presence  => true
   belongs_to :request, :inverse_of => :actions

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -9,6 +9,6 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   def user_context
-    @user_context ||= UserContext.new(Insights::API::Common::Request.current!)
+    Thread.current[:user]
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,14 +1,19 @@
 require "acts_as_tenant"
 
 class ApplicationRecord < ActiveRecord::Base
+  include Pundit
+
   self.abstract_class = true
-  attribute :metadata, ActiveRecord::Type::Json.new
 
   def metadata
-    { :user_capabilities => {} }
+    user_context.nil? ? { :user_capabilities => {} } : {:user_capabilities => policy_name.new(user_context, self).user_capabilities}
   end
 
   def user_context
     Thread.current[:user]
+  end
+
+  def policy_name
+    PolicyFinder.new(self).policy
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -5,15 +5,7 @@ class ApplicationRecord < ActiveRecord::Base
 
   self.abstract_class = true
 
-  def metadata
-    user_context.nil? ? { :user_capabilities => {} } : {:user_capabilities => policy_name.new(user_context, self).user_capabilities}
-  end
-
   def user_context
-    Thread.current[:user]
-  end
-
-  def policy_name
-    PolicyFinder.new(self).policy
+    UserContext.current_user_context
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,8 +1,6 @@
 require "acts_as_tenant"
 
 class ApplicationRecord < ActiveRecord::Base
-  include Pundit
-
   self.abstract_class = true
 
   def user_context

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,4 +2,13 @@ require "acts_as_tenant"
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+  attribute :metadata, ActiveRecord::Type::Json.new
+
+  def metadata
+    { :user_capabilities => {} }
+  end
+
+  def user_context
+    @user_context ||= UserContext.new(Insights::API::Common::Request.current!)
+  end
 end

--- a/app/models/concerns/metadata.rb
+++ b/app/models/concerns/metadata.rb
@@ -9,7 +9,11 @@ module Metadata
     end
 
     def user_capabilities
-      user_context.nil? ? { } : policy_name.new(user_context, self).user_capabilities
+      user_context.nil? ? { } : policy_class.new(user_context, self).user_capabilities
+    end
+
+    def policy_class
+      "#{self.class}Policy".constantize
     end
   end
 end

--- a/app/models/concerns/metadata.rb
+++ b/app/models/concerns/metadata.rb
@@ -1,0 +1,15 @@
+module Metadata
+  extend ActiveSupport::Concern
+
+  included do
+    attribute :metadata, ActiveRecord::Type::Json.new
+
+    def metadata
+      { :user_capabilities => user_capabilities }
+    end
+
+    def user_capabilities
+      user_context.nil? ? { } : policy_name.new(user_context, self).user_capabilities
+    end
+  end
+end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -72,6 +72,10 @@ class Request < ApplicationRecord
     FINISHED_STATES.include?(state)
   end
 
+  def metadata
+    {:user_capabilities => RequestPolicy.new(user_context, self).user_capabilities}
+  end
+
   private
 
   def set_defaults

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -84,8 +84,4 @@ class Request < ApplicationRecord
     self.number_of_children = 0
     self.number_of_finished_children = 0
   end
-
-  def policy_name
-    RequestPolicy
-  end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -2,9 +2,9 @@ class Request < ApplicationRecord
   include ApprovalStates
   include ApprovalDecisions
   include OwnerField
+  include Metadata
 
   acts_as_tenant(:tenant)
-  attribute :metadata, ActiveRecord::Type::Json.new
 
   belongs_to :request_context, :optional => false
   belongs_to :workflow
@@ -83,5 +83,9 @@ class Request < ApplicationRecord
 
     self.number_of_children = 0
     self.number_of_finished_children = 0
+  end
+
+  def policy_name
+    RequestPolicy
   end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -4,6 +4,7 @@ class Request < ApplicationRecord
   include OwnerField
 
   acts_as_tenant(:tenant)
+  attribute :metadata, ActiveRecord::Type::Json.new
 
   belongs_to :request_context, :optional => false
   belongs_to :workflow
@@ -70,10 +71,6 @@ class Request < ApplicationRecord
 
   def finished?
     FINISHED_STATES.include?(state)
-  end
-
-  def metadata
-    user_context.nil? ? super : {:user_capabilities => RequestPolicy.new(user_context, self).user_capabilities}
   end
 
   private

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -73,7 +73,7 @@ class Request < ApplicationRecord
   end
 
   def metadata
-    {:user_capabilities => RequestPolicy.new(user_context, self).user_capabilities}
+    user_context.nil? ? super : {:user_capabilities => RequestPolicy.new(user_context, self).user_capabilities}
   end
 
   private

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -7,6 +7,10 @@ class Template < ApplicationRecord
 
   before_destroy :delete_passwords
 
+  def metadata
+    {:user_capabilities => TemplatePolicy.new(user_context, self).user_capabilities}
+  end
+
   def self.seed
     template = find_or_create_by!(:title => 'Basic')
     template.update_attributes(

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -1,7 +1,8 @@
 class Template < ApplicationRecord
+  include Metadata
+
   acts_as_tenant(:tenant, :has_global_records => true)
 
-  attribute :metadata, ActiveRecord::Type::Json.new
   has_many :workflows, -> { order(:id => :asc) }, :inverse_of => :template
 
   validates :title, :presence => :title
@@ -56,5 +57,9 @@ class Template < ApplicationRecord
 
     signal_password_id = signal_setting.try(:[], 'password')
     Encryption.destroy(signal_password_id) if signal_password_id
+  end
+
+  def policy_name
+    TemplatePolicy
   end
 end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -1,15 +1,12 @@
 class Template < ApplicationRecord
   acts_as_tenant(:tenant, :has_global_records => true)
 
+  attribute :metadata, ActiveRecord::Type::Json.new
   has_many :workflows, -> { order(:id => :asc) }, :inverse_of => :template
 
   validates :title, :presence => :title
 
   before_destroy :delete_passwords
-
-  def metadata
-    user_context.nil? ? super : {:user_capabilities => TemplatePolicy.new(user_context, self).user_capabilities}
-  end
 
   def self.seed
     template = find_or_create_by!(:title => 'Basic')

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -58,8 +58,4 @@ class Template < ApplicationRecord
     signal_password_id = signal_setting.try(:[], 'password')
     Encryption.destroy(signal_password_id) if signal_password_id
   end
-
-  def policy_name
-    TemplatePolicy
-  end
 end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -8,7 +8,7 @@ class Template < ApplicationRecord
   before_destroy :delete_passwords
 
   def metadata
-    {:user_capabilities => TemplatePolicy.new(user_context, self).user_capabilities}
+    user_context.nil? ? super : {:user_capabilities => TemplatePolicy.new(user_context, self).user_capabilities}
   end
 
   def self.seed

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -27,6 +27,6 @@ class Workflow < ApplicationRecord
   end
 
   def metadata
-    {:user_capabilities => WorkflowPolicy.new(user_context, self).user_capabilities}
+    user_context.nil? ? super : {:user_capabilities => WorkflowPolicy.new(user_context, self).user_capabilities}
   end
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -1,6 +1,7 @@
 class Workflow < ApplicationRecord
   acts_as_tenant(:tenant)
 
+  attribute :metadata, ActiveRecord::Type::Json.new
   acts_as_list :scope => [:tenant_id], :column => 'sequence'
   default_scope { order(:sequence => :asc) }
 
@@ -24,9 +25,5 @@ class Workflow < ApplicationRecord
 
   def external_signal?
     template&.signal_setting.present?
-  end
-
-  def metadata
-    user_context.nil? ? super : {:user_capabilities => WorkflowPolicy.new(user_context, self).user_capabilities}
   end
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -25,4 +25,8 @@ class Workflow < ApplicationRecord
   def external_signal?
     template&.signal_setting.present?
   end
+
+  def metadata
+    {:user_capabilities => WorkflowPolicy.new(user_context, self).user_capabilities}
+  end
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -1,7 +1,7 @@
 class Workflow < ApplicationRecord
+  include Metadata
   acts_as_tenant(:tenant)
 
-  attribute :metadata, ActiveRecord::Type::Json.new
   acts_as_list :scope => [:tenant_id], :column => 'sequence'
   default_scope { order(:sequence => :asc) }
 
@@ -25,5 +25,9 @@ class Workflow < ApplicationRecord
 
   def external_signal?
     template&.signal_setting.present?
+  end
+
+  def policy_name
+    WorkflowPolicy
   end
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -26,8 +26,4 @@ class Workflow < ApplicationRecord
   def external_signal?
     template&.signal_setting.present?
   end
-
-  def policy_name
-    WorkflowPolicy
-  end
 end

--- a/app/policies/action_policy.rb
+++ b/app/policies/action_policy.rb
@@ -1,15 +1,14 @@
 class ActionPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      # Must through a request
-      raise Exceptions::NotAuthorizedError, "Not authorized to directly access actions" if scope == Action
-
       if user.params[:request_id]
         req = Request.find(user.params[:request_id])
         raise Exceptions::NotAuthorizedError, "Read access not authorized for request #{req.id}" unless resource_check('read', req)
-      end
 
-      scope
+        req.actions
+      else # Both GraphQL and direct access are not allowed 
+        raise Exceptions::NotAuthorizedError, "Not authorized to directly access actions"
+      end
     end
   end
 

--- a/app/policies/action_policy.rb
+++ b/app/policies/action_policy.rb
@@ -3,6 +3,12 @@ class ActionPolicy < ApplicationPolicy
     def resolve
       # Must through a request
       raise Exceptions::NotAuthorizedError, "Not authorized to directly access actions" if scope == Action
+
+      if user.params[:request_id]
+        req = Request.find(user.params[:request_id])
+        raise Exceptions::NotAuthorizedError, "Read access not authorized for request #{req.id}" unless resource_check('read', req)
+      end
+
       scope
     end
   end

--- a/app/policies/action_policy.rb
+++ b/app/policies/action_policy.rb
@@ -1,9 +1,4 @@
 class ActionPolicy < ApplicationPolicy
-
-  ADMIN_OPERATIONS     = [Action::MEMO_OPERATION, Action::APPROVE_OPERATION, Action::DENY_OPERATION, Action::CANCEL_OPERATION].freeze
-  APPROVER_OPERATIONS  = [Action::MEMO_OPERATION, Action::APPROVE_OPERATION, Action::DENY_OPERATION].freeze
-  REQUESTER_OPERATIONS = [Action::CANCEL_OPERATION].freeze
-
   class Scope < ApplicationPolicy::Scope
     def resolve
       # Must through a request
@@ -13,16 +8,11 @@ class ActionPolicy < ApplicationPolicy
   end
 
   def create?
-    permission_check('create', record)
-    validate_create_action
+    permission_check('create', record) ? validate_create_action : false
   end
 
   def show?
     resource_check('read')
-  end
-
-  def query?
-    permission_check('read', record)
   end
 
   private
@@ -32,9 +22,9 @@ class ActionPolicy < ApplicationPolicy
     uuid = user.request.headers['x-rh-random-access-key']
 
     valid_operation =
-      admin?(record, 'create') && ADMIN_OPERATIONS.include?(operation) ||
-      approver?(record, 'create') && APPROVER_OPERATIONS.include?(operation) ||
-      requester?(record, 'create') && REQUESTER_OPERATIONS.include?(operation) ||
+      admin?(record, 'create') && Action::ADMIN_OPERATIONS.include?(operation) ||
+      approver?(record, 'create') && Action::APPROVER_OPERATIONS.include?(operation) ||
+      requester?(record, 'create') && Action::REQUESTER_OPERATIONS.include?(operation) ||
 
       uuid.present? && Request.find(user.params[:request_id]).try(:random_access_keys).any? { |key| key.access_key == uuid }
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -36,10 +36,6 @@ class ApplicationPolicy
     false
   end
 
-  def query?
-    permission_check('read', record)
-  end
-
   def user_capabilities
     capabilities = {}
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -36,6 +36,20 @@ class ApplicationPolicy
     false
   end
 
+  def query?
+    permission_check('read', record)
+  end
+
+  def user_capabilities
+    capabilities = {}
+
+    (self.class.instance_methods(false).select {|method| method.to_s.end_with?("?")}).each do |method|
+      capabilities[method.to_s.delete_suffix('?')] = self.send(method)
+    end
+
+    capabilities
+  end
+
   class Scope
     include Mixins::RBACMixin
 

--- a/app/policies/mixins/rbac_mixin.rb
+++ b/app/policies/mixins/rbac_mixin.rb
@@ -10,13 +10,9 @@ module Mixins
       klass = record.class
       return permission_check(verb, klass) unless [Request, Action].include?(klass)
 
-      if admin?(klass, verb)
-        true
-      elsif approver?(klass, verb) && approver_accessible?(record) || requester?(klass, verb) && requester_accessible?(record)
-        true
-      else
-        false
-      end
+      admin?(klass, verb) ||
+        approver?(klass, verb) && approver_accessible?(record) ||
+        requester?(klass, verb) && requester_accessible?(record)
     end
 
     def permission_check(verb, klass = @record.class)

--- a/app/policies/request_policy.rb
+++ b/app/policies/request_policy.rb
@@ -6,19 +6,24 @@ class RequestPolicy < ApplicationPolicy
 
     def resolve
       return scope.all unless user.rbac_enabled?
-      klass = scope == Request ? scope : scope.model
 
-      case Insights::API::Common::Request.current.headers[Insights::API::Common::Request::PERSONA_KEY]
-      when PERSONA_ADMIN
-        raise Exceptions::NotAuthorizedError, "No permission to access the complete list of requests" unless admin?(klass)
-        scope == Request ? scope.where(:parent_id => nil) : scope
-      when PERSONA_APPROVER
-        raise Exceptions::NotAuthorizedError, "No permission to access requests assigned to approvers" unless approver?(klass)
-        approver_visible_requests(scope)
-      when PERSONA_REQUESTER, nil
-        scope == Request ? scope.by_owner.where(:parent_id => nil) : scope
+      if user.params[:request_id]
+        req = Request.find(user.params[:request_id])
+        raise Exceptions::NotAuthorizedError, "Read access not authorized for request #{req.id}" unless resource_check('read', req.id, Request)
+        scope
       else
-        raise Exceptions::NotAuthorizedError, "Unknown persona"
+        case Insights::API::Common::Request.current.headers[Insights::API::Common::Request::PERSONA_KEY]
+        when PERSONA_ADMIN
+          raise Exceptions::NotAuthorizedError, "No permission to access the complete list of requests" unless admin?(scope.model)
+          scope.where(:parent_id => nil)
+        when PERSONA_APPROVER
+          raise Exceptions::NotAuthorizedError, "No permission to access requests assigned to approvers" unless approver?(scope.model)
+          approver_visible_requests(scope)
+        when PERSONA_REQUESTER, nil
+          scope.by_owner.where(:parent_id => nil)
+        else
+          raise Exceptions::NotAuthorizedError, "Unknown persona"
+        end
       end
     end
   end
@@ -32,8 +37,43 @@ class RequestPolicy < ApplicationPolicy
     resource_check('read')
   end
 
-  # define for graphql
-  def query?
-    permission_check('read', record)
+  def user_capabilities
+    super.merge(valid_actions_hash)
+  end
+
+  def valid_actions_hash
+    hash = { Action::APPROVE_OPERATION => false,
+             Action::CANCEL_OPERATION  => false,
+             Action::DENY_OPERATION    => false,
+             Action::MEMO_OPERATION    => true }
+
+    actions = if admin?(record.class)
+                Action::ADMIN_OPERATIONS & valid_actions_on_state
+              elsif approver?(record.class)
+                Action::APPROVER_OPERATIONS & valid_actions_on_state
+              else
+                Action::REQUESTER_OPERATIONS & valid_actions_on_state
+              end
+
+    # only child request can be approved/denied
+    actions -= [Action::APPROVE_OPERATION, Action::DENY_OPERATION] if record.parent?
+    # only root can be cancelled
+    actions -= [Action::CANCEL_OPERATION] unless record.root?
+
+    actions.map { |action| hash[action] = true }
+
+    hash
+  end
+
+  def valid_actions_on_state(state = record.state)
+    {
+      Request::PENDING_STATE   => [Action::START_OPERATION, Action::SKIP_OPERATION, Action::CANCEL_OPERATION, Action::ERROR_OPERATION],
+      Request::STARTED_STATE   => [Action::NOTIFY_OPERATION, Action::ERROR_OPERATION, Action::CANCEL_OPERATION],
+      Request::NOTIFIED_STATE  => [Action::APPROVE_OPERATION, Action::DENY_OPERATION, Action::CANCEL_OPERATION, Action::ERROR_OPERATION],
+      Request::SKIPPED_STATE   => [Action::MEMO_OPERATION],
+      Request::FAILED_STATE    => [Action::MEMO_OPERATION],
+      Request::COMPLETED_STATE => [Action::MEMO_OPERATION],
+      Request::CANCELED_STATE  => [Action::MEMO_OPERATION]
+    }[state]
   end
 end

--- a/app/policies/request_policy.rb
+++ b/app/policies/request_policy.rb
@@ -14,10 +14,10 @@ class RequestPolicy < ApplicationPolicy
       else
         case Insights::API::Common::Request.current.headers[Insights::API::Common::Request::PERSONA_KEY]
         when PERSONA_ADMIN
-          raise Exceptions::NotAuthorizedError, "No permission to access the complete list of requests" unless admin?(scope.model)
+          raise Exceptions::NotAuthorizedError, "No permission to access the complete list of requests" unless admin?(scope)
           scope.where(:parent_id => nil)
         when PERSONA_APPROVER
-          raise Exceptions::NotAuthorizedError, "No permission to access requests assigned to approvers" unless approver?(scope.model)
+          raise Exceptions::NotAuthorizedError, "No permission to access requests assigned to approvers" unless approver?(scope)
           approver_visible_requests(scope)
         when PERSONA_REQUESTER, nil
           scope.by_owner.where(:parent_id => nil)

--- a/app/policies/template_policy.rb
+++ b/app/policies/template_policy.rb
@@ -8,9 +8,4 @@ class TemplatePolicy < ApplicationPolicy
   def show?
     permission_check('read')
   end
-
-  # define for graphql
-  def query?
-    permission_check('read', record)
-  end
 end

--- a/app/policies/user_context.rb
+++ b/app/policies/user_context.rb
@@ -19,4 +19,20 @@ class UserContext
   def rbac_enabled?
     @rbac_enabled ||= Insights::API::Common::RBAC::Access.enabled?
   end
+
+  def self.current_user_context
+    Thread.current[:user_context]
+  end
+  
+  def self.with_user_context(user_context)
+    saved_user_context   = Thread.current[:user_context]
+    self.current_user_context = user_context
+    yield
+  ensure
+    Thread.current[:user_context] = saved_user_context
+  end
+  
+  def self.current_user_context=(user_context)
+    Thread.current[:user_context] = user_context
+  end
 end

--- a/app/policies/user_context.rb
+++ b/app/policies/user_context.rb
@@ -1,7 +1,7 @@
 class UserContext
   attr_reader :request, :params
 
-  def initialize(request, params)
+  def initialize(request, params = nil)
     @request = request
     @params = params
   end

--- a/app/policies/workflow_policy.rb
+++ b/app/policies/workflow_policy.rb
@@ -6,7 +6,8 @@ class WorkflowPolicy < ApplicationPolicy
   end
 
   def create?
-    permission_check('create', record)
+    klass = record.class == Workflow ? record.class : record
+    permission_check('create', klass)
   end
 
   def show?
@@ -27,9 +28,5 @@ class WorkflowPolicy < ApplicationPolicy
 
   def unlink?
     permission_check('unlink')
-  end
-
-  def query?
-    permission_check('read', record)
   end
 end

--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -1310,6 +1310,12 @@
                         "type": "string",
                         "description": "Parent request id",
                         "readOnly": true
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "title": "Metadata",
+                      "description": "JSON Metadata about the request",
+                      "readOnly": true
                     }
                 }
             },
@@ -1331,6 +1337,12 @@
                     },
                     "description": {
                         "type": "string",
+                        "readOnly": true
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "title": "Metadata",
+                        "description": "JSON Metadata about the template",
                         "readOnly": true
                     }
                 }
@@ -1368,6 +1380,12 @@
                             "$ref": "#/components/schemas/GroupRef"
                         },
                         "uniqueItems": true
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "title": "Metadata",
+                        "description": "JSON Metadata about the workflow",
+                        "readOnly": true
                     }
                 }
             },

--- a/spec/controllers/v1.0/graphql_controller_spec.rb
+++ b/spec/controllers/v1.0/graphql_controller_spec.rb
@@ -1,22 +1,30 @@
 RSpec.describe Api::V1x0::GraphqlController, :type => :request do
   include_context "approval_rbac_objects"
-  let(:encoded_user) { encoded_user_hash }
-  let(:headers) { { 'x-rh-identity' => encoded_user } }
   let(:tenant) { create(:tenant) }
 
   let!(:template) { create(:template) }
   let(:template_id) { template.id }
   let!(:workflows) { create_list(:workflow, 4, :template => template, :tenant => tenant) }
   let(:id) { workflows.first.id }
+  let!(:parent_request) { create(:request) }
+  let!(:child_requests) { create_list(:request, 2, :parent_id => parent_request.id, :tenant => tenant) }
+  let!(:actions1) { create_list(:action, 2, :request_id => child_requests.first.id, :tenant => tenant) }
+  let!(:actions2) { create_list(:action, 2, :request_id => child_requests.second.id, :tenant => tenant) }
 
   let(:api_version) { version }
 
   let(:graphql_source_query) { { 'query' => '{ workflows {  id template_id name  } }' } }
+  let(:graphql_requests_query) { { 'query' => "{ requests(filter: { parent_id: #{parent_request.id} }) { id actions { id operation } description parent_id } }" } }
+
+  let(:headers_with_admin) { RequestSpecHelper.default_headers.merge(Insights::API::Common::Request::PERSONA_KEY => 'approval/admin') }
+  let(:headers_with_approver) { RequestSpecHelper.default_headers.merge(Insights::API::Common::Request::PERSONA_KEY => 'approval/approver') }
+  let(:headers_with_requester) { RequestSpecHelper.default_headers.merge(Insights::API::Common::Request::PERSONA_KEY => 'approval/requester') }
 
   before { allow(Insights::API::Common::RBAC::Service).to receive(:call).with(RBACApiClient::AccessApi).and_yield(double) }
 
   describe 'a simple graphql query' do
     context 'rbac allows' do
+      let(:headers) { headers_with_admin }
       before { allow(Insights::API::Common::RBAC::Service).to receive(:paginate).and_return(admin_acls) }
 
       it 'selects attributes in workflows' do
@@ -32,12 +40,55 @@ RSpec.describe Api::V1x0::GraphqlController, :type => :request do
       end
     end
 
-    xcontext 'rbac rejects' do
+    context 'rbac rejects' do
+      let(:headers) { headers_with_approver }
       before { allow(Insights::API::Common::RBAC::Service).to receive(:paginate).and_return(approver_acls) }
 
       it 'selects attributes in workflows' do
         post "#{api_version}/graphql", :headers => headers, :params => graphql_source_query
         expect(response.status).to eq(403)
+      end
+    end
+
+    context 'requests with admin role' do
+      let(:headers) { headers_with_admin }
+      before { allow(Insights::API::Common::RBAC::Service).to receive(:paginate).and_return(admin_acls) }
+
+      it 'return requests' do
+        post "#{api_version}/graphql", :headers => headers, :params => graphql_requests_query
+
+        expect(response.status).to eq(200)
+
+        results = JSON.parse(response.body).fetch_path("data", "requests")
+        expect(results.size).to eq(2)
+        results.each do |hash|
+          expect(hash.keys).to contain_exactly('id', 'actions', 'description', 'parent_id')
+          expect(hash['actions'].size).to eq(2)
+        end
+      end
+    end
+
+    context 'requests with apporver role' do
+      let(:headers) { headers_with_approver }
+      before { allow(Insights::API::Common::RBAC::Service).to receive(:paginate).and_return(approver_acls) }
+
+      it 'return 403' do
+        post "#{api_version}/graphql", :headers => headers, :params => graphql_requests_query
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context 'requests with user role' do
+      let(:headers) { headers_with_requester }
+      before { allow(Insights::API::Common::RBAC::Service).to receive(:paginate).and_return(requester_acls) }
+
+      it 'return empty requests' do
+        post "#{api_version}/graphql", :headers => headers, :params => graphql_requests_query
+
+        expect(response.status).to eq(200)
+
+        results = JSON.parse(response.body).fetch_path("data", "requests")
+        expect(results.size).to eq(0)
       end
     end
   end

--- a/spec/controllers/v1.0/templates_controller_spec.rb
+++ b/spec/controllers/v1.0/templates_controller_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Api::V1x0::TemplatesController, :type => :request do
         expect(json['links']['first']).to match(/limit=5&offset=0/)
         expect(json['data'].size).to eq(5)
         expect(response).to have_http_status(200)
+        expect(json['data'].first['metadata']).to have_key("user_capabilities")
       end
     end
 
@@ -56,6 +57,7 @@ RSpec.describe Api::V1x0::TemplatesController, :type => :request do
         template = templates.first
         expect(json).not_to be_empty
         expect(json['id']).to eq(template.id.to_s)
+        expect(json["metadata"]["user_capabilities"]).to eq("show" => true)
       end
 
       it 'admin role returns status code 200' do

--- a/spec/controllers/v1.0/workflows_controller_spec.rb
+++ b/spec/controllers/v1.0/workflows_controller_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
         expect(json['links']['first']).to match(/limit=5&offset=0/)
         expect(json['links']['last']).to match(/limit=5&offset=15/)
         expect(json['data'].size).to eq(5)
+        expect(json['data'].first['metadata']).to have_key("user_capabilities")
       end
     end
 
@@ -161,6 +162,14 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
 
         expect(json).not_to be_empty
         expect(json['id']).to eq(workflow.id.to_s)
+        expect(json["metadata"]["user_capabilities"]).to eq(
+          "create"  => true,
+          "destroy" => true,
+          "link"    => true,
+          "show"    => true,
+          "unlink"  => true,
+          "update"  => true
+        )
       end
 
       it 'returns status code 200' do
@@ -204,6 +213,14 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
         get "#{api_version}/workflows/#{id}", :headers => default_headers
 
         expect(response).to have_http_status(200)
+        expect(json["metadata"]["user_capabilities"]).to eq(
+          "create"  => false,
+          "destroy" => false,
+          "link"    => false,
+          "show"    => true,
+          "unlink"  => false,
+          "update"  => false
+        )
       end
     end
 

--- a/spec/policies/action_policy_scope_spec.rb
+++ b/spec/policies/action_policy_scope_spec.rb
@@ -4,13 +4,13 @@ describe ActionPolicy::Scope do
   let(:request) { create(:request) }
   let(:actions) { create_list(:action, 3, :request => request) }
   let(:access) { instance_double(Insights::API::Common::RBAC::Access, :scopes => ['admin']) }
-  let(:params) { { :request_id => request.id } }
   let(:user) { instance_double(UserContext, :params => params, :access => access, :rbac_enabled? => true) }
   let(:subject) { described_class.new(user, query) }
 
   describe '#resolve' do
     context 'when query is a scope' do
       let(:query) { Action.all }
+      let(:params) { { :request_id => request.id } }
 
       it 'returns actions' do
         expect(subject.resolve).to match_array(actions)
@@ -19,6 +19,7 @@ describe ActionPolicy::Scope do
 
     context 'when query is model name' do
       let(:query) { Action }
+      let(:params) { { :id => request.id } }
 
       it 'raises an error' do
         expect { subject.resolve }.to raise_error(Exceptions::NotAuthorizedError)

--- a/spec/policies/action_policy_scope_spec.rb
+++ b/spec/policies/action_policy_scope_spec.rb
@@ -3,7 +3,10 @@ describe ActionPolicy::Scope do
 
   let(:request) { create(:request) }
   let(:actions) { create_list(:action, 3, :request => request) }
-  let(:subject) { described_class.new(instance_double(UserContext), query) }
+  let(:access) { instance_double(Insights::API::Common::RBAC::Access, :scopes => ['admin']) }
+  let(:params) { { :request_id => request.id } }
+  let(:user) { instance_double(UserContext, :params => params, :access => access, :rbac_enabled? => true) }
+  let(:subject) { described_class.new(user, query) }
 
   describe '#resolve' do
     context 'when query is a scope' do

--- a/spec/policies/action_policy_spec.rb
+++ b/spec/policies/action_policy_spec.rb
@@ -20,10 +20,6 @@ describe ActionPolicy do
       it '#create?' do
         expect(subject.create?).to be_truthy
       end
-
-      it '#query?' do
-        expect(subject.query?).to be_truthy
-      end
     end
 
     context 'when action resource is instance' do
@@ -45,10 +41,6 @@ describe ActionPolicy do
 
       it '#create?' do
         expect(subject.create?).to be_truthy
-      end
-
-      it '#query?' do
-        expect(subject.query?).to be_truthy
       end
     end
 
@@ -79,10 +71,6 @@ describe ActionPolicy do
 
       it '#create?' do
         expect(subject.create?).to be_truthy
-      end
-
-      it '#query?' do
-        expect(subject.query?).to be_truthy
       end
     end
 

--- a/spec/policies/request_policy_spec.rb
+++ b/spec/policies/request_policy_spec.rb
@@ -17,10 +17,6 @@ describe RequestPolicy do
       it '#create?' do
         expect(subject.create?).to be_truthy
       end
-
-      it '#query?' do
-        expect(subject.query?).to be_truthy
-      end
     end
 
     context 'when record is an instance' do
@@ -43,15 +39,6 @@ describe RequestPolicy do
 
       it '#create?' do
         expect(subject.create?).to be_falsey
-      end
-    end
-
-    context 'when record is model class' do
-      let(:subject) { described_class.new(user, Request) }
-      let(:accessible_flag) { true }
-
-      it '#query?' do
-        expect(subject.query?).to be_truthy
       end
     end
 
@@ -87,10 +74,6 @@ describe RequestPolicy do
 
       it '#create?' do
         expect(subject.create?).to be_truthy
-      end
-
-      it '#query?' do
-        expect(subject.query?).to be_truthy
       end
     end
 

--- a/spec/policies/template_policy_spec.rb
+++ b/spec/policies/template_policy_spec.rb
@@ -1,18 +1,18 @@
 describe TemplatePolicy do
   include_context "approval_rbac_objects"
 
-  let(:templates) { create_list(:template, 3) }
+  let(:template) { create(:template) }
   let(:access) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => accessible_flag) }
   let(:user) { instance_double(UserContext, :rbac_enabled? => true, :access => access) }
 
-  subject { described_class.new(user, Template) }
+  subject { described_class.new(user, template) }
 
-  describe '#query?' do
+  describe '#show?' do
     context 'when admin role' do
       let(:accessible_flag) { true }
 
       it 'returns templates' do
-        expect(subject.query?).to be_truthy
+        expect(subject.show?).to be_truthy
       end
     end
 
@@ -20,7 +20,7 @@ describe TemplatePolicy do
       let(:accessible_flag) { false }
 
       it 'returns templates' do
-        expect(subject.query?).to be_falsey
+        expect(subject.show?).to be_falsey
       end
     end
 
@@ -28,7 +28,7 @@ describe TemplatePolicy do
       let(:accessible_flag) { false }
 
       it 'returns templates' do
-        expect(subject.query?).to be_falsey
+        expect(subject.show?).to be_falsey
       end
     end
   end

--- a/spec/policies/workflow_policy_spec.rb
+++ b/spec/policies/workflow_policy_spec.rb
@@ -15,10 +15,6 @@ describe WorkflowPolicy do
       it '#create?' do
         expect(subject.create?).to be_truthy
       end
-
-      it '#query?' do
-        expect(subject.query?).to be_truthy
-      end
     end
 
     context 'with instance' do
@@ -47,10 +43,6 @@ describe WorkflowPolicy do
       it '#create?' do
         expect(subject.create?).to be_falsey
       end
-
-      it '#query?' do
-        expect(subject.query?).to be_falsey
-      end
     end
 
     context 'with instance' do
@@ -78,10 +70,6 @@ describe WorkflowPolicy do
 
       it '#show?' do
         expect(subject.show?).to be_truthy
-      end
-
-      it '#query?' do
-        expect(described_class.new(user, Workflow).query?).to be_truthy
       end
     end
 


### PR DESCRIPTION
Added user capabilities feature in Approval. The user_capabilities in metadata will have following keys. Values can be either true or false:

1. Template: `"metadata"=>{"user_capabilities"=>{"show"=>true}}`
2. Workflow: `"metadata"=>{"user_capabilities"=>{"update"=>true, "destroy"=>true, "link"=>true, "unlink"=>true, "create"=>true, "show"=>true}}`
3. Request:  `"metadata"=>{"user_capabilities"=>{"approve"=>true, "cancel"=>true, "create"=>true, "deny"=>true, "memo"=>true, "show"=>true}}`

Also having refactoring, moved `authorize` check logic in `index` to corresponding `policy scope`.