### PR TITLE
Changed specs to allow user read actions

### DIFF
--- a/spec/controllers/v1.0/actions_controller_spec.rb
+++ b/spec/controllers/v1.0/actions_controller_spec.rb
@@ -88,15 +88,15 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
       end
     end
 
-    context 'requester role cannot read' do
+    context 'requester role can read' do
       before { setup_requester_role }
 
-      it 'returns status code 403' do
+      it 'returns status code 200' do
         with_modified_env :APP_NAME => app_name do
           get "#{api_version}/actions/#{id}", :headers => default_headers
         end
 
-        expect(response).to have_http_status(403)
+        expect(response).to have_http_status(200)
       end
     end
   end
@@ -147,16 +147,16 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
       end
     end
 
-    context 'requester role cannot get actions' do
+    context 'requester role can get actions' do
       before do
         id
         setup_requester_role
       end
 
-      it 'returns status code 403' do
+      it 'returns status code 200' do
         get "#{api_version}/requests/#{request.id}/actions", :headers => default_headers
 
-        expect(response).to have_http_status(403)
+        expect(response).to have_http_status(200)
       end
     end
   end

--- a/spec/support/rbac_shared_contexts.rb
+++ b/spec/support/rbac_shared_contexts.rb
@@ -28,10 +28,12 @@ RSpec.shared_context "approval_rbac_objects" do
   let(:requester_request_read_acl) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:requests:read", :resource_definitions => [user_resource_def]) }
   let(:requester_request_create_acl) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:requests:create", :resource_definitions => [user_resource_def]) }
   let(:requester_action_create_acl) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:actions:create", :resource_definitions => [user_resource_def]) }
+  let(:requester_action_read_acl) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:actions:read", :resource_definitions => [user_resource_def]) }
   let(:requester_workflow_read_acl) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:workflows:read", :resource_definitions => [admin_resource_def]) }
 
   let(:admin_acls) { [template_read_acl, workflow_create_acl, workflow_read_acl, workflow_destroy_acl, workflow_update_acl, request_create_acl,
                       workflow_link_acl, workflow_unlink_acl, request_read_acl, action_create_acl, action_read_acl] }
   let(:approver_acls) { [approver_request_read_acl, approver_action_create_acl, approver_action_read_acl] }
-  let(:requester_acls) { [requester_request_read_acl, requester_request_create_acl, requester_action_create_acl, requester_workflow_read_acl] }
+  let(:requester_acls) { [requester_request_read_acl, requester_request_create_acl, requester_action_create_acl, requester_action_read_acl,
+                          requester_workflow_read_acl] }
 end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1382

The permission `approval:actions:read` for `Approval user` has been added in https://github.com/RedHatInsights/rbac-config/pull/38. This PR only updated spec files to test it