### PR TITLE
Query performance optimization

### DIFF
--- a/app/controllers/api/v1x0/actions_controller.rb
+++ b/app/controllers/api/v1x0/actions_controller.rb
@@ -5,7 +5,7 @@ module Api
 
       def index
         req = Request.find(params.require(:request_id))
-        authorize req
+        authorize req, :show?
 
         collection(policy_scope(req.actions))
       end

--- a/app/controllers/api/v1x0/requests_controller.rb
+++ b/app/controllers/api/v1x0/requests_controller.rb
@@ -20,7 +20,7 @@ module Api
       def index
         relation = if params[:request_id]
                      req = Request.find(params.require(:request_id))
-                     authorize req
+                     authorize req, :show?
                      req.children
                    else
                      Request

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -19,7 +19,6 @@ class Request < ApplicationRecord
 
   scope :decision,       ->(decision)       { where(:decision => decision) }
   scope :state,          ->(state)          { where(:state => state) }
-  scope :owner,          ->(owner)          { where(:owner => owner) }
   scope :requester_name, ->(requester_name) { where(:requester_name => requester_name) }
   scope :group_ref,      ->(group_ref)      { where(:group_ref => group_ref) }
   default_scope { order(:created_at => :desc) }

--- a/app/policies/action_policy.rb
+++ b/app/policies/action_policy.rb
@@ -6,18 +6,9 @@ class ActionPolicy < ApplicationPolicy
 
   class Scope < ApplicationPolicy::Scope
     def resolve
-      raise Exceptions::NotAuthorizedError, "Read access not authorized for #{scope}" unless permission_check('read', scope.model)
-
-      if admin?(scope.model)
-        scope.all
-      elsif approver?(scope.model)
-        scope.where(:id => approver_id_list(scope.model.table_name))
-      elsif requester?(scope.model)
-        scope.where(:id => owner_id_list(scope.table_name))
-      else
-        Rails.logger.error("Error in request resolve: scope does not include admin, group, or user. List of scopes: #{scope.model}")
-        scope.none
-      end
+      # Must through a request
+      raise Exceptions::NotAuthorizedError, "Not authorized to directly access actions" if scope == Action
+      scope
     end
   end
 

--- a/app/policies/mixins/rbac_mixin.rb
+++ b/app/policies/mixins/rbac_mixin.rb
@@ -4,12 +4,15 @@ module Mixins
 
     APPROVER_VISIBLE_STATES = [ApprovalStates::NOTIFIED_STATE, ApprovalStates::COMPLETED_STATE].freeze
 
-    def resource_check(verb, id = @record.id, klass = @record.class)
+    def resource_check(verb, record = @record)
       return true unless @user.rbac_enabled?
+
+      klass = record.class
+      return permission_check(verb, klass) unless [Request, Action].include?(klass)
 
       if admin?(klass, verb)
         true
-      elsif approver?(klass, verb) && approvable?(klass.table_name, id) || requester?(klass, verb) && owned?(klass.table_name, id)
+      elsif approver?(klass, verb) && approver_accessible?(record) || requester?(klass, verb) && requester_accessible?(record)
         true
       else
         false
@@ -34,58 +37,28 @@ module Mixins
       scopes(klass, verb).include?("user")
     end
 
-    # check if approver can process the #{resource} with #{id}
-    def approvable?(resource, id)
-      approver_id_list(resource)&.include?(id.to_i)
-    end
-
-    # check if regular requester own the #{resource} with #{id}
-    def owned?(resource, id)
-      owner_id_list(resource)&.include?(id.to_i)
-    end
-
-    # resource ids approver can access
-    def approver_id_list(resource)
-      visible_request_ids = visible_request_ids_for_approver
-      Rails.logger.debug { "Final accessible request ids: #{visible_request_ids}" }
-
-      case resource
-      when "requests"
-        visible_request_ids
-      when "actions"
-        Action.where(:request_id => visible_request_ids).pluck(:id).sort
-      else
-        raise ArgumentError, "Unknown resource type: #{resource}"
-      end
-    end
-
-    # resource ids owner owns
-    def owner_id_list(resource)
-      case resource
-      when "requests"
-        owner_request_ids
-      when "actions"
-        Action.where(:request_id => owner_request_ids).pluck(:id).sort
-      else
-        raise ArgumentError, "Unknown resource type: #{resource}"
-      end
-    end
-
-    def owner_request_ids
-      Request.by_owner.pluck(:id).sort
-    end
-
-    # All child request ids for approver to process
-    def visible_request_ids_for_approver
-      Request.where(:group_ref => @user.group_uuids, :state => APPROVER_VISIBLE_STATES).pluck(:id)
+    def approver_visible_requests(scope)
+      scope.where(:group_ref => @user.group_uuids, :state => APPROVER_VISIBLE_STATES)
     end
 
     def scopes(klass, verb)
       access.scopes(klass.table_name, verb)
     end
-    
+
     def access
       @user.access
+    end
+
+    private
+
+    def approver_accessible?(record)
+      record = record.request if record.kind_of?(Action)
+      @user.group_uuids.include?(record.group_ref) && APPROVER_VISIBLE_STATES.include?(record.state)
+    end
+
+    def requester_accessible?(record)
+      record = record.request if record.kind_of?(Action)
+      record.owner == Insights::API::Common::Request.current.user.username
     end
   end
 end

--- a/app/policies/request_policy.rb
+++ b/app/policies/request_policy.rb
@@ -14,9 +14,9 @@ class RequestPolicy < ApplicationPolicy
         scope == Request ? scope.where(:parent_id => nil) : scope
       when PERSONA_APPROVER
         raise Exceptions::NotAuthorizedError, "No permission to access requests assigned to approvers" unless approver?(klass)
-        scope.where(:id => approver_id_list(scope.table_name))
+        approver_visible_requests(scope)
       when PERSONA_REQUESTER, nil
-        scope == Request ? scope.where(:parent_id => nil, :id => owner_id_list(scope.table_name)) : scope
+        scope == Request ? scope.by_owner.where(:parent_id => nil) : scope
       else
         raise Exceptions::NotAuthorizedError, "Unknown persona"
       end
@@ -32,11 +32,6 @@ class RequestPolicy < ApplicationPolicy
     resource_check('read')
   end
 
-  # only for child requests
-  def index?
-    resource_check('read', record.id, record.class)
-  end
- 
   # define for graphql
   def query?
     permission_check('read', record)

--- a/spec/policies/action_policy_scope_spec.rb
+++ b/spec/policies/action_policy_scope_spec.rb
@@ -3,36 +3,19 @@ describe ActionPolicy::Scope do
 
   let(:request) { create(:request) }
   let(:actions) { create_list(:action, 3, :request => request) }
-  let(:access) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => accessible_flag) }
-  let(:params) { { :request_id => request.id } }
-  let(:user) { instance_double(UserContext, :params => params, :access => access, :rbac_enabled? => true) }
-  let(:subject) { described_class.new(user, Action.all) }
+  let(:subject) { described_class.new(instance_double(UserContext), query) }
 
   describe '#resolve' do
-    context 'when admin role' do
-      let(:accessible_flag) { true }
-      before { allow(access).to receive(:scopes).and_return(['admin']) }
+    context 'when query is a scope' do
+      let(:query) { Action.all }
 
       it 'returns actions' do
         expect(subject.resolve).to match_array(actions)
       end
     end
 
-    context 'when approver role' do
-      let(:accessible_flag) { true }
-
-      before do
-        allow(subject).to receive(:approver_id_list).and_return([actions.first.id, actions.last.id, request.id])
-        allow(access).to receive(:scopes).and_return(['group'])
-      end
-
-      it 'returns actions' do
-        expect(subject.resolve.sort).to eq(Action.where(:id => [actions.first.id, actions.last.id]).sort)
-      end
-    end
-
-    context 'when requester role' do
-      let(:accessible_flag) { false }
+    context 'when query is model name' do
+      let(:query) { Action }
 
       it 'raises an error' do
         expect { subject.resolve }.to raise_error(Exceptions::NotAuthorizedError)

--- a/spec/policies/action_policy_spec.rb
+++ b/spec/policies/action_policy_spec.rb
@@ -3,15 +3,15 @@ describe ActionPolicy do
 
   let(:request) { create(:request) }
   let(:actions) { create_list(:action, 3, :request => request) }
-  let(:access) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => accessible_flag) }
-  let(:user) { instance_double(UserContext, :access => access, :rbac_enabled? => true) }
+  let(:access) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true) }
+  let(:group_uuids) { ['group_uid'] }
+  let(:user) { instance_double(UserContext, :access => access, :rbac_enabled? => true, :group_uuids => group_uuids) }
 
   before do
     allow(subject).to receive(:validate_create_action).and_return(true)
   end
 
   describe 'with admin role' do
-    let(:accessible_flag) { true }
     before { allow(access).to receive(:scopes).and_return(['admin']) }
 
     context 'when action resource is model class' do
@@ -36,9 +36,7 @@ describe ActionPolicy do
   end
 
   describe 'with approver role' do
-    let(:accessible_flag) { true }
     before do
-      allow(subject).to receive(:approver_id_list).and_return([actions.first.id, actions.last.id])
       allow(access).to receive(:scopes).and_return(['group'])
     end
 
@@ -55,18 +53,18 @@ describe ActionPolicy do
     end
 
     context 'when action resource is instance' do
-      context 'when id is in the approver_id_list' do
-        let(:subject) { described_class.new(user, actions.first) }
+      let(:subject) { described_class.new(user, actions.first) }
 
-        it '#show?' do
+      context 'when approver is assigned to approve the request' do
+        before { request.update(:group_ref => group_uuids.first, :state => 'notified') }
+
+        it 'is allowed to show the action instance' do
           expect(subject.show?).to be_truthy
         end
       end
 
-      context 'when id is not in the approver_id_list' do
-        let(:subject) { described_class.new(user, actions.second) }
-
-        it '#show? with the id not in the list' do
+      context 'when approver is not assigned to approve the request' do
+        it 'is not allowed to show the action instance' do
           expect(subject.show?).to be_falsey
         end
       end
@@ -74,37 +72,41 @@ describe ActionPolicy do
   end
 
   describe 'with requester role' do
-    before do
-      allow(subject).to receive(:owner_id_list).and_return([actions.first.id, actions.last.id])
-    end
+    before { allow(access).to receive(:scopes).and_return(['user']) }
 
     context 'when action resource is model class' do
-      let(:accessible_flag) { true }
       let(:subject) { described_class.new(user, Action) }
-      before { allow(access).to receive(:scopes).and_return(['user']) }
 
       it '#create?' do
         expect(subject.create?).to be_truthy
       end
-    end
-
-    context 'when action resource is model class, permission_check is false' do
-      let(:accessible_flag) { false }
-      let(:subject) { described_class.new(user, Action) }
-      before { allow(access).to receive(:scopes).and_return([]) }
 
       it '#query?' do
-        expect(subject.query?).to be_falsey
+        expect(subject.query?).to be_truthy
       end
     end
 
     context 'when action resource is instance' do
-      let(:subject) { described_class.new(user, actions.first) }
-      let(:accessible_flag) { false }
-      before { allow(access).to receive(:scopes).and_return([]) }
+      around do |example|
+        Insights::API::Common::Request.with_request(RequestSpecHelper.default_request_hash) do
+          example.call
+        end
+      end
 
-      it '#show?' do
-        expect(subject.show?).to be_falsey
+      let(:subject) { described_class.new(user, actions.first) }
+
+      context 'when requester is owner of the request' do
+        it 'is allowed to show the action instance' do
+          expect(subject.show?).to be_truthy
+        end
+      end
+
+      context 'when requester is not owner of the request' do
+        before { request.update(:owner => 'ugly name') }
+
+        it 'is not allowed to show the action instance' do
+          expect(subject.show?).to be_falsey
+        end
       end
     end
   end

--- a/spec/policies/request_policy_scope_spec.rb
+++ b/spec/policies/request_policy_scope_spec.rb
@@ -1,10 +1,11 @@
 describe RequestPolicy::Scope do
   include_context "approval_rbac_objects"
 
+  let(:group_uuids) { ['group-uuid'] }
   let!(:requests) { create_list(:request, 3) }
   let!(:sub_requests) { create_list(:request, 2, :parent_id => requests.first.id) }
   let(:access) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => true) }
-  let(:user) { instance_double(UserContext, :access => access, :rbac_enabled? => true) }
+  let(:user) { instance_double(UserContext, :access => access, :rbac_enabled? => true, :group_uuids => group_uuids) }
   let(:subject) { described_class.new(user, scope) }
   let(:headers_with_admin) { RequestSpecHelper.default_headers.merge(Insights::API::Common::Request::PERSONA_KEY => 'approval/admin') }
   let(:headers_with_approver) { RequestSpecHelper.default_headers.merge(Insights::API::Common::Request::PERSONA_KEY => 'approval/approver') }
@@ -28,13 +29,14 @@ describe RequestPolicy::Scope do
     context 'when approver role' do
       let(:req_headers) { headers_with_approver }
       before do
-        allow(subject).to receive(:approver_id_list).and_return([requests.first.id, requests.last.id])
+        sub_requests.first.update(:group_ref => group_uuids.first, :state => 'completed')
+        requests.last.update(:group_ref => group_uuids.first, :state => 'notified')
         allow(access).to receive(:scopes).and_return(['group'])
       end
 
       it 'returns requests' do
         Insights::API::Common::Request.with_request(headers) do
-          expect(subject.resolve.sort).to eq(Request.where(:id => [requests.first.id, requests.last.id]).sort)
+          expect(subject.resolve.sort).to eq(Request.where(:id => [sub_requests.first.id, requests.last.id]).sort)
         end
       end
     end
@@ -42,12 +44,13 @@ describe RequestPolicy::Scope do
     context 'when requester role' do
       let(:req_headers) { headers_with_requester }
       before do
-        allow(subject).to receive(:owner_id_list).and_return([requests.second.id])
         allow(access).to receive(:scopes).and_return(['user'])
       end
 
       it 'returns requests' do
         Insights::API::Common::Request.with_request(headers) do
+          requests.second.update(:owner => Insights::API::Common::Request.current.user.username)
+
           expect(subject.resolve.count).to eq(1)
           expect(subject.resolve.first).to eq(requests.second)
         end

--- a/spec/policies/request_policy_spec.rb
+++ b/spec/policies/request_policy_spec.rb
@@ -3,7 +3,9 @@ describe RequestPolicy do
 
   let(:requests) { create_list(:request, 3) }
   let(:access) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => accessible_flag) }
-  let(:user) { instance_double(UserContext, :access => access, :rbac_enabled? => true) }
+  let(:group_uuids) { ['group-uuid'] }
+  let(:user) { instance_double(UserContext, :access => access, :rbac_enabled? => true, :group_uuids => group_uuids) }
+  let(:headers) { {:headers => RequestSpecHelper::default_headers, :original_url=>'url'} }
 
   describe 'with admin role' do
     let(:accessible_flag) { true }
@@ -32,7 +34,6 @@ describe RequestPolicy do
 
   describe 'with approver role' do
     before do
-      allow(subject).to receive(:approver_id_list).and_return([requests.first.id, requests.last.id])
       allow(access).to receive(:scopes).and_return(['group'])
     end
 
@@ -54,20 +55,21 @@ describe RequestPolicy do
       end
     end
 
-    context 'when id is in the approver_id_list' do
+    context 'when record is a request approvable by approver' do
       let(:subject) { described_class.new(user, requests.first) }
       let(:accessible_flag) { true }
+      before { requests.first.update(:group_ref => group_uuids.first, :state => 'completed') }
 
-      it '#show? with the id in the list' do
+      it 'can be shown to the approver' do
         expect(subject.show?).to be_truthy
       end
     end
 
-    context 'when id is not in the approver_id_list' do
+    context 'when record is a request not approvable by approver' do
       let(:subject) { described_class.new(user, requests.second) }
       let(:accessible_flag) { true }
 
-      it '#show? with the id not in the list' do
+      it 'cannot be shown to the approver' do
         expect(subject.show?).to be_falsey
       end
     end
@@ -77,7 +79,6 @@ describe RequestPolicy do
     let(:accessible_flag) { true }
 
     before do
-      allow(subject).to receive(:owner_id_list).and_return([requests.first.id, requests.last.id])
       allow(access).to receive(:scopes).and_return(['user'])
     end
 
@@ -93,19 +94,27 @@ describe RequestPolicy do
       end
     end
 
-    context 'when id is in the owner_id_list' do
+    context 'when record is a request created by user' do
       let(:subject) { described_class.new(user, requests.first) }
 
-      it '#show? with the id in the list' do
-        expect(subject.show?).to be_truthy
+      it 'can be shown to user' do
+        Insights::API::Common::Request.with_request(headers) do
+          requests.first.update(:owner => Insights::API::Common::Request.current.user.username)
+
+          expect(subject.show?).to be_truthy
+        end
       end
     end
 
-    context 'when id is not in the owner_id_list' do
+    context 'when record is a request not created by user' do
       let(:subject) { described_class.new(user, requests.second) }
 
-      it '#show? with the id no5 in the list' do
-        expect(subject.show?).to be_falsey
+      it 'cannot be shown to user' do
+        Insights::API::Common::Request.with_request(headers) do
+          requests.second.update(:owner => 'ugly name')
+
+          expect(subject.show?).to be_falsey
+        end
       end
     end
   end

--- a/spec/support/rbac_shared_contexts.rb
+++ b/spec/support/rbac_shared_contexts.rb
@@ -28,10 +28,11 @@ RSpec.shared_context "approval_rbac_objects" do
   let(:requester_request_read_acl) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:requests:read", :resource_definitions => [user_resource_def]) }
   let(:requester_request_create_acl) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:requests:create", :resource_definitions => [user_resource_def]) }
   let(:requester_action_create_acl) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:actions:create", :resource_definitions => [user_resource_def]) }
+  let(:requester_action_read_acl) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:actions:read", :resource_definitions => [user_resource_def]) }
   let(:requester_workflow_read_acl) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:workflows:read", :resource_definitions => [admin_resource_def]) }
 
   let(:admin_acls) { [template_read_acl, workflow_create_acl, workflow_read_acl, workflow_destroy_acl, workflow_update_acl, request_create_acl,
                       workflow_link_acl, workflow_unlink_acl, request_read_acl, action_create_acl, action_read_acl] }
   let(:approver_acls) { [approver_request_read_acl, approver_action_create_acl, approver_action_read_acl] }
-  let(:requester_acls) { [requester_request_read_acl, requester_request_create_acl, requester_action_create_acl, requester_workflow_read_acl] }
+  let(:requester_acls) { [requester_request_read_acl, requester_request_create_acl, requester_action_create_acl, requester_action_read_acl, requester_workflow_read_acl] }
 end


### PR DESCRIPTION
The main purpose is to remove the need of get id list of approver or requester visible resources. All queries are direct. As a result the super long query string with all IDs should not appear in the log.

Prove the requester is now able to see actions. Fixed spec for this query.
