### PR TITLE
Add `sort_by` option from common gem to index operations

### DIFF
--- a/app/controllers/api/v1x0/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/index_mixin.rb
@@ -16,7 +16,8 @@ module Api
             :base_query => filtered(scoped(base_query)),
             :request    => request,
             :limit      => pagination_limit,
-            :offset     => pagination_offset
+            :offset     => pagination_offset,
+            :sort_by    => query_sort_by
           ).response
 
           json_response(resp)

--- a/app/controllers/api/v1x0/workflows_controller.rb
+++ b/app/controllers/api/v1x0/workflows_controller.rb
@@ -79,7 +79,8 @@ module Api
           :base_query => filtered(scoped(base_query)),
           :request    => request,
           :limit      => params[:limit],
-          :offset     => params[:offset]
+          :offset     => params[:offset],
+          :sort_by    => params[:sort_by]
         ).response
 
         json_response(resp)

--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -216,6 +216,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/filter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/sort_by"
                     }
                 ],
                 "responses": {
@@ -425,6 +428,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/filter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/sort_by"
                     }
                 ],
                 "responses": {
@@ -520,6 +526,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/filter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/sort_by"
                     }
                 ],
                 "responses": {
@@ -573,6 +582,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/filter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/sort_by"
                     }
                 ],
                 "responses": {
@@ -979,6 +991,15 @@
                 "explode": true,
                 "schema": {
                     "type": "object"
+                }
+            },
+            "sort_by": {
+                "name": "sort_by",
+                "in": "query",
+                "description": "Parameter to sort collection",
+                "required": false,
+                "schema": {
+                    "type": "string"
                 }
             },
             "persona": {

--- a/spec/controllers/v1.0/workflows_controller_spec.rb
+++ b/spec/controllers/v1.0/workflows_controller_spec.rb
@@ -140,6 +140,16 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
     end
   end
 
+  describe 'GET /workflows with sort_by' do
+    before { allow(rs_class).to receive(:paginate).and_return(admin_acls) }
+
+    it "allows sorting via parameter" do
+      get "#{api_version}/workflows?sort_by=name", :headers => default_headers
+
+      expect(json["data"].map { |workflow| workflow["name"] }.sort).to eq workflows.map(&:name).sort
+    end
+  end
+
   describe 'GET /workflows/:id' do
     context 'admin role when the record exists' do
       before { allow(rs_class).to receive(:paginate).and_return(admin_acls) }


### PR DESCRIPTION
Same as I did for catalog here: https://github.com/RedHatInsights/catalog-api/pull/647

This allows the user to add `?sort_by=field` to sort the index by any field. 

cc @gmcculloug @bzwei 