### PR TITLE
Fix to allow graphql to fetch child requests

### DIFF
--- a/app/controllers/api/v1x0/graphql_controller.rb
+++ b/app/controllers/api/v1x0/graphql_controller.rb
@@ -17,7 +17,7 @@ module Api
         {
           "^.*$" => {
             "base_query" => lambda do |model_class, _ctx|
-              policy_scope(model_class)
+              policy_scope(model_class.all)
             end
           }
         }


### PR DESCRIPTION
In GraphQL controller we now pass a scope rather than the model class itself, so that the `parent_id` will be not force to set to `nil` in https://github.com/RedHatInsights/approval-api/blob/stable/app/policies/request_policy.rb#L14