### PR TITLE
Lock api-common to 3.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 
 gem 'acts_as_list',        '~> 1.0'
 gem 'faraday',             '>= 0.17.0'
-gem 'insights-api-common', '~> 3.8'
+gem 'insights-api-common', '= 3.9'
 gem 'jbuilder',            '~> 2.0'
 gem 'manageiq-loggers',    '~> 0.2'
 gem 'manageiq-messaging',  '~> 0.1'


### PR DESCRIPTION
Fixes failing tests with api-common 3.10