### PR TITLE
Used GraphQL params to narrow policy scopes

### DIFF
--- a/app/controllers/api/v1x0/graphql_controller.rb
+++ b/app/controllers/api/v1x0/graphql_controller.rb
@@ -17,6 +17,7 @@ module Api
         {
           "^.*$" => {
             "base_query" => lambda do |model_class, graphql_args, _ctx|
+              UserContext.current_user_context.graphql_params = graphql_args
               policy_scope(model_class.all)
             end
           }

--- a/app/controllers/api/v1x0/graphql_controller.rb
+++ b/app/controllers/api/v1x0/graphql_controller.rb
@@ -18,7 +18,7 @@ module Api
           "^.*$" => {
             "base_query" => lambda do |model_class, graphql_args, _ctx|
               UserContext.current_user_context.graphql_params = graphql_args
-              policy_scope(model_class.all)
+              policy_scope(model_class)
             end
           }
         }

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -11,8 +11,9 @@ class Request < ApplicationRecord
   has_many :actions, -> { order(:id => :asc) }, :dependent => :destroy, :inverse_of => :request
   has_many :random_access_keys, :dependent => :destroy, :inverse_of => :request
 
-  belongs_to :parent,   :foreign_key => :parent_id, :class_name => 'Request', :inverse_of => :children
-  has_many   :children, :foreign_key => :parent_id, :class_name => 'Request', :inverse_of => :parent, :dependent => :destroy
+  belongs_to :parent,   :foreign_key => :parent_id, :class_name => 'Request', :inverse_of => :requests
+  has_many   :requests, :foreign_key => :parent_id, :class_name => 'Request', :inverse_of => :parent, :dependent => :destroy
+  alias_method :children, :requests
 
   validates :name,     :presence  => true
   validates :state,    :inclusion => { :in => STATES }

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -22,6 +22,7 @@ class Request < ApplicationRecord
   scope :state,          ->(state)          { where(:state => state) }
   scope :requester_name, ->(requester_name) { where(:requester_name => requester_name) }
   scope :group_ref,      ->(group_ref)      { where(:group_ref => group_ref) }
+  scope :root_requests,  ->                 { where(:parent_id => nil) }
   default_scope { order(:created_at => :desc) }
 
   delegate :content, :to => :request_context

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -13,7 +13,6 @@ class Request < ApplicationRecord
 
   belongs_to :parent,   :foreign_key => :parent_id, :class_name => 'Request', :inverse_of => :requests
   has_many   :requests, :foreign_key => :parent_id, :class_name => 'Request', :inverse_of => :parent, :dependent => :destroy
-  alias_method :children, :requests
 
   validates :name,     :presence  => true
   validates :state,    :inclusion => { :in => STATES }
@@ -31,13 +30,13 @@ class Request < ApplicationRecord
   after_initialize :set_defaults
 
   def invalidate_number_of_children
-    update(:number_of_children => children.size)
+    update(:number_of_children => requests.size)
   end
 
   def invalidate_number_of_finished_children
     return if number_of_children.zero?
 
-    update(:number_of_finished_children => children.count(&:finished?))
+    update(:number_of_finished_children => requests.count(&:finished?))
   end
 
   def create_child

--- a/app/policies/action_policy.rb
+++ b/app/policies/action_policy.rb
@@ -1,6 +1,8 @@
 class ActionPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
+      return graphql_id_query if graphql_query_by_id?
+
       if user.params[:request_id]
         req = Request.find(user.params[:request_id])
         raise Exceptions::NotAuthorizedError, "Read access not authorized for request #{req.id}" unless resource_check('read', req)

--- a/app/policies/action_policy.rb
+++ b/app/policies/action_policy.rb
@@ -1,14 +1,12 @@
 class ActionPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
-    def resolve
-      return graphql_id_query if graphql_query_by_id?
-
+    def resolve_scope
       if user.params[:request_id]
         req = Request.find(user.params[:request_id])
         raise Exceptions::NotAuthorizedError, "Read access not authorized for request #{req.id}" unless resource_check('read', req)
 
         req.actions
-      else # Both GraphQL and direct access are not allowed 
+      else # Both GraphQL and direct access are not allowed
         raise Exceptions::NotAuthorizedError, "Not authorized to directly access actions"
       end
     end
@@ -28,11 +26,9 @@ class ActionPolicy < ApplicationPolicy
     operation = user.params.require(:operation)
     uuid = user.request.headers['x-rh-random-access-key']
 
-    valid_operation =
-      admin?(record, 'create') && Action::ADMIN_OPERATIONS.include?(operation) ||
+    admin?(record, 'create') && Action::ADMIN_OPERATIONS.include?(operation) ||
       approver?(record, 'create') && Action::APPROVER_OPERATIONS.include?(operation) ||
       requester?(record, 'create') && Action::REQUESTER_OPERATIONS.include?(operation) ||
-
       uuid.present? && Request.find(user.params[:request_id]).try(:random_access_keys).any? { |key| key.access_key == uuid }
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -59,5 +59,34 @@ class ApplicationPolicy
     def resolve
       scope.all
     end
+
+    def graphql_id_query
+      id = user.graphql_params.id
+
+      item = scope.find(id)
+      raise Exceptions::NotAuthorizedError, "Read access not authorized for request #{item.id}" unless resource_check('read', item)
+
+      scope.where(:id => id)
+    end
+
+    def graphql_filter_query
+      scope.where(user.graphql_params.filter)
+    end
+
+    def graphql_collection_query
+      graphql_query_by_filter? ? graphql_filter_query : scope.all
+    end
+
+    def graphql_query_by_id?
+      graphql_query? && user.graphql_params.id.present?
+    end
+
+    def graphql_query_by_filter?
+      graphql_query? && user.graphql_params.filter.present?
+    end
+
+    def graphql_query?
+      !!user.graphql_params
+    end
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -39,8 +39,8 @@ class ApplicationPolicy
   def user_capabilities
     capabilities = {}
 
-    (self.class.instance_methods(false).select {|method| method.to_s.end_with?("?")}).each do |method|
-      capabilities[method.to_s.delete_suffix('?')] = self.send(method)
+    (self.class.instance_methods(false).select { |method| method.to_s.end_with?("?") }).each do |method|
+      capabilities[method.to_s.delete_suffix('?')] = send(method)
     end
 
     capabilities
@@ -57,6 +57,14 @@ class ApplicationPolicy
     end
 
     def resolve
+      return scope.all unless user.rbac_enabled?
+
+      graphql_query_by_id? ? graphql_id_query : resolve_scope
+    end
+
+    def resolve_scope
+      raise Exceptions::NotAuthorizedError, "Read access not authorized for #{scope}" unless permission_check('read', scope)
+
       scope.all
     end
 
@@ -66,19 +74,11 @@ class ApplicationPolicy
       item = scope.find(id)
       raise Exceptions::NotAuthorizedError, "Read access not authorized for request #{item.id}" unless resource_check('read', item)
 
-      scope.where(:id => id)
-    end
-
-    def graphql_collection_query
-      scope.where(user.graphql_params&.filter)
+      scope
     end
 
     def graphql_query_by_id?
-      graphql_query? && user.graphql_params.id.present?
-    end
-
-    def graphql_query?
-      !!user.graphql_params
+      !!user.graphql_params&.id
     end
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -69,20 +69,12 @@ class ApplicationPolicy
       scope.where(:id => id)
     end
 
-    def graphql_filter_query
-      scope.where(user.graphql_params.filter)
-    end
-
     def graphql_collection_query
-      graphql_query_by_filter? ? graphql_filter_query : scope.all
+      scope.where(user.graphql_params&.filter)
     end
 
     def graphql_query_by_id?
       graphql_query? && user.graphql_params.id.present?
-    end
-
-    def graphql_query_by_filter?
-      graphql_query? && user.graphql_params.filter.present?
     end
 
     def graphql_query?

--- a/app/policies/request_policy.rb
+++ b/app/policies/request_policy.rb
@@ -11,7 +11,7 @@ class RequestPolicy < ApplicationPolicy
       if user.params[:request_id]
         req = Request.find(user.params[:request_id])
         raise Exceptions::NotAuthorizedError, "Read access not authorized for request #{req.id}" unless resource_check('read', req)
-        req.children
+        req.requests
       else
         case Insights::API::Common::Request.current.headers[Insights::API::Common::Request::PERSONA_KEY]
         when PERSONA_ADMIN

--- a/app/policies/template_policy.rb
+++ b/app/policies/template_policy.rb
@@ -1,11 +1,5 @@
 class TemplatePolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
-    def resolve
-      return graphql_id_query if graphql_query_by_id?
-      raise Exceptions::NotAuthorizedError, "Read access not authorized for #{scope}" unless permission_check('read', scope)
-
-      graphql_query? ? graphql_collection_query : scope.all
-    end
   end
 
   def show?

--- a/app/policies/template_policy.rb
+++ b/app/policies/template_policy.rb
@@ -1,7 +1,10 @@
 class TemplatePolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      permission_check('read', scope) ? scope.all : (raise Exceptions::NotAuthorizedError, "Read access not authorized for #{scope}")
+      return graphql_id_query if graphql_query_by_id?
+      raise Exceptions::NotAuthorizedError, "Read access not authorized for #{scope}" unless permission_check('read', scope)
+
+      graphql_query? ? graphql_collection_query : scope.all
     end
   end
 

--- a/app/policies/user_context.rb
+++ b/app/policies/user_context.rb
@@ -15,6 +15,14 @@ class UserContext
       Insights::API::Common::RBAC::Service.paginate(api, :list_groups, :scope => 'principal').collect(&:uuid)
     end
   end
+  
+  def graphql_params=(val)
+    @graphql_params = val
+  end
+
+  def graphql_params
+    @graphql_params
+  end
 
   def rbac_enabled?
     @rbac_enabled ||= Insights::API::Common::RBAC::Access.enabled?

--- a/app/policies/workflow_policy.rb
+++ b/app/policies/workflow_policy.rb
@@ -1,11 +1,5 @@
 class WorkflowPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
-    def resolve
-      return graphql_id_query if graphql_query_by_id?
-      raise Exceptions::NotAuthorizedError, "Read access not authorized for #{scope}" unless permission_check('read', scope)
-
-      graphql_query? ? graphql_collection_query : scope.all
-    end
   end
 
   def create?

--- a/app/policies/workflow_policy.rb
+++ b/app/policies/workflow_policy.rb
@@ -1,7 +1,10 @@
 class WorkflowPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      permission_check('read', scope) ? scope.all : (raise Exceptions::NotAuthorizedError, "Read access not authorized for #{scope}")
+      return graphql_id_query if graphql_query_by_id?
+      raise Exceptions::NotAuthorizedError, "Read access not authorized for #{scope}" unless permission_check('read', scope)
+
+      graphql_query? ? graphql_collection_query : scope.all
     end
   end
 

--- a/app/services/request_create_service.rb
+++ b/app/services/request_create_service.rb
@@ -58,7 +58,7 @@ class RequestCreateService
   end
 
   def update_root_group_name(request)
-    request.update!(:group_name => request.children.map(&:group_name).reverse.join(","))
+    request.update!(:group_name => request.requests.map(&:group_name).reverse.join(","))
   end
 
   def default_approve?
@@ -86,7 +86,7 @@ class RequestCreateService
 
     start_request(request)
 
-    sub_requests = request.parent? ? request.children : [request]
+    sub_requests = request.parent? ? request.requests : [request]
 
     sub_requests.reverse.each { |req| group_auto_approve(req, sleep_time) }
   end
@@ -112,7 +112,7 @@ class RequestCreateService
   def sub_request_ids(request)
     return [request.id] if request.leaf?
 
-    last = request.children.last
+    last = request.requests.last
     Request.where(:parent_id => last.parent_id, :workflow_id => last.workflow_id).pluck(:id)
   end
 end

--- a/app/services/request_update_service.rb
+++ b/app/services/request_update_service.rb
@@ -116,7 +116,7 @@ class RequestUpdateService
   end
 
   def leaves
-    request.root.children.reverse # sort from oldest to latest
+    request.root.requests.reverse # sort from oldest to latest
   end
 
   def next_pending_leaves

--- a/spec/controllers/v1.0/graphql_controller_spec.rb
+++ b/spec/controllers/v1.0/graphql_controller_spec.rb
@@ -6,29 +6,36 @@ RSpec.describe Api::V1x0::GraphqlController, :type => :request do
   let(:template_id) { template.id }
   let!(:workflows) { create_list(:workflow, 4, :template => template, :tenant => tenant) }
   let(:id) { workflows.first.id }
-  let!(:parent_request) { create(:request) }
+  let!(:parent_request) { create(:request, :tenant => tenant) }
   let!(:child_requests) { create_list(:request, 2, :parent_id => parent_request.id, :tenant => tenant) }
   let!(:actions1) { create_list(:action, 2, :request_id => child_requests.first.id, :tenant => tenant) }
   let!(:actions2) { create_list(:action, 2, :request_id => child_requests.second.id, :tenant => tenant) }
 
   let(:api_version) { version }
 
-  let(:graphql_source_query) { { 'query' => '{ workflows {  id template_id name  } }' } }
-  let(:graphql_requests_query) { { 'query' => "{ requests(filter: { parent_id: #{parent_request.id} }) { id actions { id operation } description parent_id } }" } }
+  let(:graphql_simple_query) { { 'query' => '{ workflows {  id template_id name  } }' } }
+  let(:graphql_id_query) { { 'query' => "{ requests(id: #{parent_request.id}) { id requests { id parent_id actions { id operation } } description parent_id } }" } }
+  let(:graphql_filter_query) { { 'query' => "{ requests(filter: { parent_id: #{parent_request.id} }) { id actions { id operation } description parent_id } }" } }
 
   let(:headers_with_admin) { RequestSpecHelper.default_headers.merge(Insights::API::Common::Request::PERSONA_KEY => 'approval/admin') }
   let(:headers_with_approver) { RequestSpecHelper.default_headers.merge(Insights::API::Common::Request::PERSONA_KEY => 'approval/approver') }
   let(:headers_with_requester) { RequestSpecHelper.default_headers.merge(Insights::API::Common::Request::PERSONA_KEY => 'approval/requester') }
 
-  before { allow(Insights::API::Common::RBAC::Service).to receive(:call).with(RBACApiClient::AccessApi).and_yield(double) }
+  before do
+    allow(Insights::API::Common::RBAC::Service).to receive(:call).with(RBACApiClient::AccessApi).and_yield(double)
+    allow(user).to receive(:graphql_params=).and_return(user)
+  end
 
   describe 'a simple graphql query' do
+    let(:graphql_params) { double("graphql_params", :id => nil, :filter => nil) }
+
     context 'rbac allows' do
       let(:headers) { headers_with_admin }
+
       before { admin_access }
 
       it 'selects attributes in workflows' do
-        post "#{api_version}/graphql", :headers => headers, :params => graphql_source_query
+        post "#{api_version}/graphql", :headers => headers, :params => graphql_simple_query
 
         expect(response.status).to eq(200)
 
@@ -45,25 +52,35 @@ RSpec.describe Api::V1x0::GraphqlController, :type => :request do
       before { approver_access }
 
       it 'selects attributes in workflows' do
-        post "#{api_version}/graphql", :headers => headers, :params => graphql_source_query
+        post "#{api_version}/graphql", :headers => headers, :params => graphql_simple_query
         expect(response.status).to eq(403)
       end
     end
+  end
+
+  describe 'a graphql query with id params' do
+    let(:user) { instance_double(UserContext, :access => access, :rbac_enabled? => true, :params => params, :graphql_params => graphql_params) }
+    let(:graphql_params) { double("graphql_params", :id => "#{parent_request.id}", :filter => nil) }
 
     context 'requests with admin role' do
       let(:headers) { headers_with_admin }
       before { admin_access }
 
       it 'return requests' do
-        post "#{api_version}/graphql", :headers => headers, :params => graphql_requests_query
+        post "#{api_version}/graphql", :headers => headers, :params => graphql_id_query
 
         expect(response.status).to eq(200)
 
         results = JSON.parse(response.body).fetch_path("data", "requests")
-        expect(results.size).to eq(2)
+        expect(results.size).to eq(1)
         results.each do |hash|
-          expect(hash.keys).to contain_exactly('id', 'actions', 'description', 'parent_id')
-          expect(hash['actions'].size).to eq(2)
+          expect(hash.keys).to contain_exactly('id', 'requests', 'description', 'parent_id')
+          expect(hash['id']).to eq(parent_request.id.to_s)
+          expect(hash['requests'].size).to eq(2)
+          hash['requests'].each do |req|
+            expect(req.keys).to contain_exactly('id', 'parent_id', 'actions')
+            expect(req['actions'].size).to eq(2)
+          end
         end
       end
     end
@@ -73,7 +90,9 @@ RSpec.describe Api::V1x0::GraphqlController, :type => :request do
       before { approver_access }
 
       it 'return 403' do
-        post "#{api_version}/graphql", :headers => headers, :params => graphql_requests_query
+        allow(user).to receive(:group_uuids).and_return([])
+
+        post "#{api_version}/graphql", :headers => headers, :params => graphql_id_query
         expect(response.status).to eq(403)
       end
     end
@@ -83,12 +102,31 @@ RSpec.describe Api::V1x0::GraphqlController, :type => :request do
       before { user_access }
 
       it 'return empty requests' do
-        post "#{api_version}/graphql", :headers => headers, :params => graphql_requests_query
+        post "#{api_version}/graphql", :headers => headers, :params => graphql_id_query
+
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+
+  describe 'a graphql query with filter params' do
+    let(:user) { instance_double(UserContext, :access => access, :rbac_enabled? => true, :params => params, :graphql_params => graphql_params) }
+    let(:graphql_params) { double("graphql_params", :id => nil, :filter => { :parent_id => "#{parent_request.id}" }) }
+
+    context 'requests with admin role' do
+      let(:headers) { headers_with_admin }
+      before { admin_access }
+
+      it 'return requests' do
+        post "#{api_version}/graphql", :headers => headers, :params => graphql_filter_query
 
         expect(response.status).to eq(200)
 
         results = JSON.parse(response.body).fetch_path("data", "requests")
-        expect(results.size).to eq(0)
+        expect(results.size).to eq(2)
+        results.each do |hash|
+          expect(hash.keys).to contain_exactly('id', 'actions', 'description', 'parent_id')
+        end
       end
     end
   end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -3,13 +3,13 @@ RSpec.describe Request, type: :model do
   it { should belong_to(:workflow) }
   it { should belong_to(:parent) }
   it { should have_many(:actions) }
-  it { should have_many(:children) }
+  it { should have_many(:requests) }
   it { should have_many(:random_access_keys) }
 
   it { should validate_presence_of(:name) }
 
   describe '#number_of_children and #number_of_finished_children' do
-    subject { FactoryBot.create(:request, :children => children) }
+    subject { FactoryBot.create(:request, :requests => children) }
 
     context 'no children' do
       let(:children) { [] }
@@ -80,7 +80,7 @@ RSpec.describe Request, type: :model do
   end
 
   describe '#parent? and #child?' do
-    subject { FactoryBot.create(:request, :children => children) }
+    subject { FactoryBot.create(:request, :requests => children) }
 
     before { subject.invalidate_number_of_children }
 

--- a/spec/policies/action_policy_scope_spec.rb
+++ b/spec/policies/action_policy_scope_spec.rb
@@ -4,7 +4,7 @@ describe ActionPolicy::Scope do
   let(:request) { create(:request) }
   let(:actions) { create_list(:action, 3, :request => request) }
   let(:access) { instance_double(Insights::API::Common::RBAC::Access, :scopes => ['admin']) }
-  let(:user) { instance_double(UserContext, :params => params, :access => access, :rbac_enabled? => true) }
+  let(:user) { instance_double(UserContext, :params => params, :access => access, :rbac_enabled? => true, :graphql_params => nil) }
   let(:subject) { described_class.new(user, query) }
 
   describe '#resolve' do

--- a/spec/policies/request_policy_scope_spec.rb
+++ b/spec/policies/request_policy_scope_spec.rb
@@ -69,7 +69,6 @@ describe RequestPolicy::Scope do
 
     before do
       allow(subject).to receive(:graphql_query_by_id?).and_return(false)
-      allow(subject).to receive(:graphql_query_by_filter?).and_return(true)
       allow(subject).to receive(:graphql_collection_query).and_return(scope)
     end
 
@@ -115,7 +114,7 @@ describe RequestPolicy::Scope do
   end
 
   describe '#resolve /requests/#{id}/requests' do
-    let!(:scope) { request.children }
+    let!(:scope) { request.requests }
     let(:params) { {:request_id => request.id} }
     let(:graphql_params) { nil }
 

--- a/spec/policies/template_policy_scope_spec.rb
+++ b/spec/policies/template_policy_scope_spec.rb
@@ -3,7 +3,7 @@ describe TemplatePolicy::Scope do
 
   let(:templates) { create_list(:template, 3) }
   let(:access) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => accessible_flag) }
-  let(:user) { instance_double(UserContext, :access => access, :rbac_enabled? => true) }
+  let(:user) { instance_double(UserContext, :access => access, :rbac_enabled? => true, :graphql_params => nil) }
   let(:subject) { described_class.new(user, Template) }
 
   describe '#resolve' do

--- a/spec/policies/workflow_policy_scope_spec.rb
+++ b/spec/policies/workflow_policy_scope_spec.rb
@@ -3,7 +3,7 @@ describe WorkflowPolicy::Scope do
 
   let(:workflows) { create_list(:workflow, 3) }
   let(:access) { instance_double(Insights::API::Common::RBAC::Access, :accessible? => accessible_flag) }
-  let(:user) { instance_double(UserContext, :access => access, :rbac_enabled? => true) }
+  let(:user) { instance_double(UserContext, :access => access, :rbac_enabled? => true, :graphql_params => nil) }
   let(:subject) { described_class.new(user, Workflow) }
 
   describe '#resolve' do

--- a/spec/services/request_create_service_spec.rb
+++ b/spec/services/request_create_service_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe RequestCreateService do
           :number_of_finished_children => 0
         )
         [0, 1].each do |index|
-          subrequest = request.children[index]
+          subrequest = request.requests[index]
           expect(subrequest).to have_attributes(
             :process_ref => '100',
             :state       => Request::STARTED_STATE,
@@ -58,8 +58,8 @@ RSpec.describe RequestCreateService do
             :workflow    => workflow2,
             :group_name  => 'gname'
           )
-          expect(request.children.first.group_ref).to eq('ref3');
-          expect(request.children.second.group_ref).to eq('ref2');
+          expect(request.requests.first.group_ref).to eq('ref3');
+          expect(request.requests.second.group_ref).to eq('ref2');
         end
       end
 
@@ -145,7 +145,7 @@ RSpec.describe RequestCreateService do
             :number_of_finished_children => 3
           )
           (0..2).each do |index|
-            child = request.children[index]
+            child = request.requests[index]
             expect(child).to have_attributes(
               :state      => Request::COMPLETED_STATE,
               :decision   => Request::APPROVED_STATUS,
@@ -165,9 +165,9 @@ RSpec.describe RequestCreateService do
               :comments  => described_class::AUTO_APPROVED_REASON
             )
           end
-          expect(request.children.first.group_ref).to eq('ref3');
-          expect(request.children.second.group_ref).to eq('ref2');
-          expect(request.children.last.group_ref).to eq('ref1');
+          expect(request.requests.first.group_ref).to eq('ref3');
+          expect(request.requests.second.group_ref).to eq('ref2');
+          expect(request.requests.last.group_ref).to eq('ref1');
         end
       end
     end

--- a/spec/support/rbac_shared_contexts.rb
+++ b/spec/support/rbac_shared_contexts.rb
@@ -5,7 +5,7 @@ RSpec.shared_context "approval_rbac_objects" do
 
   let(:params) { {} }
   let(:access) { instance_double(Insights::API::Common::RBAC::Access) }
-  let(:user) { instance_double(UserContext, :access => access, :rbac_enabled? => true, :params => params) }
+  let(:user) { instance_double(UserContext, :access => access, :rbac_enabled? => true, :params => params, :graphql_params => nil) }
 
   let(:admin_access) do
     allow(UserContext).to receive(:new).and_return(user)


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1445

This PR will process graphQL query whose params contain `id`.
