### PR TITLE
Extend approver group validation to admin group

### DIFF
--- a/app/services/mixins/group_validate_mixin.rb
+++ b/app/services/mixins/group_validate_mixin.rb
@@ -1,6 +1,4 @@
 module GroupValidateMixin
-  APPROVER_ROLE = 'Approval Approver'.freeze
-
   def validate_approver_groups(group_refs, raise_error = true)
     not_uniq = group_refs.uniq! { |ref| ref['uuid'] }
     raise Exceptions::UserError, 'Duplicated group UUID was detected' if not_uniq && raise_error
@@ -35,7 +33,7 @@ module GroupValidateMixin
       return false
     end
 
-    unless group.has_role?(APPROVER_ROLE)
+    unless group.can_approve?
       error_action(request, "Group #{group.name} does not have approver role")
       return false
     end
@@ -58,7 +56,7 @@ module GroupValidateMixin
 
   def validate_approver_group_and_raise(uuid)
     group = ensure_group(uuid)
-    raise Exceptions::UserError, "Group #{group.name} does not have approver role" unless group.has_role?(APPROVER_ROLE)
+    raise Exceptions::UserError, "Group #{group.name} does not have approver role" unless group.can_approve?
 
     {'name' => group.name, 'uuid' => uuid}
   end
@@ -66,7 +64,7 @@ module GroupValidateMixin
   def validate_approver_group_no_raise(uuid, old_name)
     name = begin
              group = ensure_group(uuid)
-             if group.has_role?(APPROVER_ROLE)
+             if group.can_approve?
                group.name
              else
                "#{group.name}(No approver permission)"

--- a/spec/controllers/v1.0/requests_controller_spec.rb
+++ b/spec/controllers/v1.0/requests_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::V1x0::RequestsController, :type => :request do
   let(:headers_with_approver)  { default_headers.merge(Insights::API::Common::Request::PERSONA_KEY => 'approval/approver') }
   let(:headers_with_requester) { default_headers.merge(Insights::API::Common::Request::PERSONA_KEY => 'approval/requester') }
 
-  let(:group1) { instance_double(Group, :name => 'group1', :uuid => "123", :has_role? => true) }
+  let(:group1) { instance_double(Group, :name => 'group1', :uuid => "123", :can_approve? => true) }
   let(:group2) { instance_double(Group, :name => 'group2', :uuid => "456") }
   let(:group3) { instance_double(Group, :name => 'group3', :uuid => "789") }
 
@@ -358,7 +358,7 @@ RSpec.describe Api::V1x0::RequestsController, :type => :request do
         'tags'        => [{:tag => '/ns1/name1=v1'}]
       }]
     end
-    let(:group) { instance_double(Group, :name => 'foo', :has_role? => true) }
+    let(:group) { instance_double(Group, :name => 'foo', :can_approve? => true) }
     let(:workflow1) { create(:workflow, :group_refs => [group1.uuid]) }
     let(:workflow2) { create(:workflow, :group_refs => [group2.uuid]) }
 

--- a/spec/controllers/v1.0/workflows_controller_spec.rb
+++ b/spec/controllers/v1.0/workflows_controller_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
     let(:uuid_2) { SecureRandom.uuid }
     let(:uuid_3) { SecureRandom.uuid }
     let(:group_refs) { [{'name' => 'n990', 'uuid' => uuid_1}, {'name' => 'n991', 'uuid' => uuid_2}, {'name' => 'n992', 'uuid' => uuid_3}] }
-    let(:group) { instance_double(Group, :name => 'group', :uuid => 990, :has_role? => true) }
+    let(:group) { instance_double(Group, :name => 'group', :uuid => 990, :can_approve? => true) }
     let(:valid_attributes) { { :name => 'Visit Narnia', :description => 'workflow_valid', :group_refs => group_refs } }
 
     before do
@@ -279,7 +279,7 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
     context 'when a request with invalid group' do
       before do
         admin_access
-        allow(group).to receive(:has_role?).and_return(false)
+        allow(group).to receive(:can_approve?).and_return(false)
       end
 
       it 'returns status code 400' do
@@ -314,7 +314,7 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
   # Test suite for PATCH /workflows/:id
   describe 'PATCH /workflows/:id' do
     let(:valid_attributes) { {:name => "test", :group_refs => [{'name' => 'n1000', 'uuid' => SecureRandom.uuid}], :sequence => 2} }
-    let(:group) { instance_double(Group, :name => 'n1000', :uuid => '1000', :has_role? => true) }
+    let(:group) { instance_double(Group, :name => 'n1000', :uuid => '1000', :can_approve? => true) }
 
     context 'admin role when item exists' do
       before do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -30,4 +30,63 @@ RSpec.describe Group do
       expect(described_class.all('myname').size).to eq(2)
     end
   end
+
+  describe '#can_approve?' do
+    around do |example|
+      Insights::API::Common::Request.with_request(RequestSpecHelper.default_request_hash) do
+        example.call
+      end
+    end
+
+    let(:ctx) { double(:ctx) }
+    let(:role_api) { double(:role_api) }
+    let(:roles) { [double(:r1, :uuid => 'uuid1').as_null_object, double(:r2, :uuid => 'uuid2').as_null_object] }
+    let(:admin_filter) { instance_double(RBACApiClient::ResourceDefinitionFilter, :key => 'scope', :operation => 'equal', :value => 'admin') }
+    let(:approver_filter) { instance_double(RBACApiClient::ResourceDefinitionFilter, :key => 'scope', :operation => 'equal', :value => 'group') }
+    let(:user_filter) { instance_double(RBACApiClient::ResourceDefinitionFilter, :key => 'scope', :operation => 'equal', :value => 'user') }
+    let(:admin_resource_def) { instance_double(RBACApiClient::ResourceDefinition, :attribute_filter => admin_filter) }
+    let(:approver_resource_def) { instance_double(RBACApiClient::ResourceDefinition, :attribute_filter => approver_filter) }
+    let(:user_resource_def) { instance_double(RBACApiClient::ResourceDefinition, :attribute_filter => user_filter) }
+    
+    let(:admin_action_create_acl) { instance_double(RBACApiClient::Access, :permission => "approval:actions:create", :resource_definitions => [admin_resource_def]) }
+    let(:approver_action_create_acl) { instance_double(RBACApiClient::Access, :permission => "approval:actions:create", :resource_definitions => [approver_resource_def]) }
+    let(:user_action_create_acl) { instance_double(RBACApiClient::Access, :permission => "approval:actions:create", :resource_definitions => [user_resource_def]) }
+    let(:request_create_acl) { instance_double(RBACApiClient::Access, :permission => "approval:requests:create", :resource_definitions => [admin_resource_def]) }
+
+    before do
+      allow(ContextService).to receive(:new).and_return(ctx)
+      allow(ctx).to receive(:as_org_admin).and_yield
+      allow(subject).to receive(:roles).and_return(roles)
+      allow(Insights::API::Common::RBAC::Service).to receive(:call).with(RBACApiClient::RoleApi, {}).and_yield(role_api)
+      allow(role_api).to receive(:get_role_access).and_return(acls)
+    end
+
+    context 'when has admin action create permissions' do
+      let(:acls) { double(:acls, :meta => double(:count => 2), :data => [admin_action_create_acl, user_action_create_acl]) }
+
+      it 'should return true' do
+        expect(ContextService).to receive(:new).once
+        expect(subject.can_approve?).to be_truthy
+
+        subject.can_approve?
+        subject.can_approve?
+      end
+    end
+
+    context 'when has approver action create permissions' do
+      let(:acls) { double(:acls, :meta => double(:count => 2), :data => [approver_action_create_acl, user_action_create_acl]) }
+
+      it 'should return true' do
+        expect(subject.can_approve?).to be_truthy
+      end
+    end
+
+    context 'when only has user action create permissions' do
+      let(:acls) { double(:acls, :meta => double(:count => 2), :data => [user_action_create_acl, request_create_acl]) }
+
+      it 'should return false' do
+        expect(subject.can_approve?).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/services/request_create_service_spec.rb
+++ b/spec/services/request_create_service_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe RequestCreateService do
   let(:workflow1) { create(:workflow, :group_refs => [{'uuid' => 'ref1'}], :template => template) }
   let(:workflow2) { create(:workflow, :group_refs => [{'uuid' => 'ref2'}, {'uuid' => 'ref3'}], :template => template) }
   let(:resolved_workflows) { [] }
-  let(:group) { instance_double(Group, :name => 'gname', :has_role? => true, :users => ['user']) }
+  let(:group) { instance_double(Group, :name => 'gname', :can_approve? => true, :users => ['user']) }
 
   before do
     allow(Thread).to receive(:new).and_yield
@@ -64,7 +64,7 @@ RSpec.describe RequestCreateService do
       end
 
       it 'creates a request with invalid group' do
-        allow(group).to receive(:has_role?).and_return(false)
+        allow(group).to receive(:can_approve?).and_return(false)
 
         expect { subject.create(:name => 'req1', :content => 'test me') }.to raise_error(Exceptions::UserError, /does not have approver role/)
       end

--- a/spec/services/request_update_service_spec.rb
+++ b/spec/services/request_update_service_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe RequestUpdateService do
   let(:request) { create(:request, :with_tenant) }
   subject { described_class.new(request.id) }
   let!(:event_service) { EventService.new(request) }
-  let(:group) { instance_double(Group, :name => 'group1', :has_role? => true, :users => ['user']) }
+  let(:group) { instance_double(Group, :name => 'group1', :can_approve? => true, :users => ['user']) }
 
   before { allow(EventService).to receive(:new).with(request).and_return(event_service) }
 
@@ -61,7 +61,7 @@ RSpec.describe RequestUpdateService do
       let(:msg) { "Group #{group.name} does not have approver role" }
 
       it 'returns false' do
-        allow(group).to receive(:has_role?).and_return(false)
+        allow(group).to receive(:can_approve?).and_return(false)
 
         expect(request.actions.count).to eq(0)
         expect(subject.runtime_validate_group(request)).to be_falsey

--- a/spec/services/workflow_create_service_spec.rb
+++ b/spec/services/workflow_create_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe WorkflowCreateService do
 
   let(:template) { create(:template) }
   let(:group_refs) { [{'name' => 'n991', 'uuid' => '991'}, {'name' => 'n992', 'uuid' => '992'}, {'name' => 'n993', 'uuid' => '993'}] }
-  let(:group) { instance_double(Group, :name => 'gname', :has_role? => true) }
+  let(:group) { instance_double(Group, :name => 'gname', :can_approve? => true) }
 
   subject { described_class.new(template.id) }
 
@@ -35,7 +35,7 @@ RSpec.describe WorkflowCreateService do
 
     context 'when the group has no approver role' do
       it 'raises an error' do
-        allow(group).to receive(:has_role?).and_return(false)
+        allow(group).to receive(:can_approve?).and_return(false)
         expect { subject.create(:name => 'workflow_1', :group_refs => group_refs) }.to raise_error(Exceptions::UserError, /does not have approver role/)
       end
     end

--- a/spec/services/workflow_find_service_spec.rb
+++ b/spec/services/workflow_find_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe WorkflowFindService do
   let(:add_tag_svc) { instance_double(AddRemoteTags) }
   let(:get_tag_svc) { instance_double(GetRemoteTags, :tags => [fq_tag_string]) }
   let(:fq_tag_string) { "/#{WorkflowLinkService::TAG_NAMESPACE}/#{WorkflowLinkService::TAG_NAME}=#{workflow.id}" }
-  let(:group) { instance_double(Group, :name => 'n999', :uuid => '990', :has_role? => true) }
+  let(:group) { instance_double(Group, :name => 'n999', :uuid => '990', :can_approve? => true) }
   let(:tag) do
     { 'tag' => fq_tag_string }
   end

--- a/spec/services/workflow_link_service_spec.rb
+++ b/spec/services/workflow_link_service_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe WorkflowLinkService, :type => :request do
     Insights::API::Common::Request.with_request(default_request_hash) { example.call }
   end
 
-  let(:group) { instance_double(Group, :name => 'gname', :uuid => '990', :has_role? => true) }
+  let(:group) { instance_double(Group, :name => 'gname', :uuid => '990', :can_approve? => true) }
   let(:workflow) { create(:workflow, :with_tenant, :group_refs => [{'name' => 'gname', 'uuid' => '990'}]) }
   let(:obj_a) { {:object_type => 'inventory', :app_name => 'topology', :object_id => '123'} }
   let(:remote_tag_svc) { instance_double(AddRemoteTags) }
@@ -27,7 +27,7 @@ RSpec.describe WorkflowLinkService, :type => :request do
     end
 
     it 'fails to add a new link when the group is invalid' do
-      allow(group).to receive(:has_role?).and_return(false)
+      allow(group).to receive(:can_approve?).and_return(false)
       expect { subject.link(obj_a) }.to raise_error(Exceptions::UserError, /does not have approver role/)
     end
 

--- a/spec/services/workflow_update_service_spec.rb
+++ b/spec/services/workflow_update_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe WorkflowUpdateService do
   context 'when update' do
     it 'with group_refs' do
       Insights::API::Common::Request.with_request(RequestSpecHelper.default_request_hash) do
-        expect(subject).to receive(:ensure_group).and_return(instance_double(Group, :name => 'newname', :has_role? => true))
+        expect(subject).to receive(:ensure_group).and_return(instance_double(Group, :name => 'newname', :can_approve? => true))
         subject.update(:group_refs => [{'name' => 'n999', 'uuid' => '999'}])
         workflow.reload
         expect(workflow.group_refs.first).to include('name' => 'newname', 'uuid' => '999')


### PR DESCRIPTION
Allow admin groups to be added to approval process

https://projects.engineering.redhat.com/browse/SSP-1435