### PR TITLE
Use rails validates for name

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -10,14 +10,7 @@ class Workflow < ApplicationRecord
   has_many :tag_links, :dependent => :destroy, :inverse_of => :workflow
   has_many :access_control_entries, :as => :aceable, :dependent => :destroy, :inverse_of => :aceable
 
-  validates :name, :presence => true
-  validate :unique_with_same_tenant
-
-  def unique_with_same_tenant
-    if name_changed? && Workflow.exists?(:name => name)
-      errors.add(:name, "has already been taken")
-    end
-  end
+  validates :name, :presence => true, :uniqueness => {:scope => :tenant}
 
   def external_processing?
     template&.process_setting.present?

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -40,9 +40,7 @@ RSpec.describe Workflow, :type => :model do
 
   context "with same name in different tenants" do
     let(:another_tenant) { create(:tenant) }
-    let(:another_workflow) do
-      create(:workflow, :name => workflow.name)
-    end
+    let(:another_workflow) { create(:workflow, :name => workflow.name) }
 
     describe "create workflow" do
       before do


### PR DESCRIPTION
Before we came up with a customized `unique_with_same_tenant` method to handle a special case for `Always Approve` workflow. Since this workflow has been removed, we can switch to use standard rails' validation for uniqueness. 