### PR TITLE
Remove unused  rescue

### DIFF
--- a/app/controllers/api/v1x0/workflows_controller.rb
+++ b/app/controllers/api/v1x0/workflows_controller.rb
@@ -38,10 +38,6 @@ module Api
         head :no_content
       rescue ActiveRecord::InvalidForeignKey => e
         json_response({ :message => e.message }, :forbidden)
-      rescue ActiveRecord::RecordNotDestroyed
-        raise unless workflow.errors[:base].include?(Workflow::MSG_PROTECTED_RECORD)
-
-        json_response({ :message => Workflow::MSG_PROTECTED_RECORD }, :forbidden)
       end
 
       def link


### PR DESCRIPTION
This `rescue` is for always approve workflow, which has been removed.