### PR TITLE
Add Github .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* linguist-vendored
+*.css linguist-vendored=false


### PR DESCRIPTION
The [library that Github](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-repository-languages) uses to detect a repo language is detect this repo as being mostly CSS, when in reality it would be more accurate to display as a Ruby repo.

![image](https://user-images.githubusercontent.com/2591569/81419487-4c186380-911c-11ea-9b44-9b6c4145b716.png)

This `.gitattributes` file will cause the library to ignore CSS files and should promote the repo and mainly a ruby based repo.