### PR TITLE
Adjust sequences only when current value changes

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -36,7 +36,7 @@ class Workflow < ApplicationRecord
 
   # move all related sequence number one higher if the desired number is in use
   def move_rest_higher
-    return unless sequence && self.class.where(:sequence => sequence).exists
+    return unless sequence && sequence_changed? && self.class.exists?(:sequence => sequence)
 
     self.class.where(table[:sequence].gteq(sequence)).update_all("sequence = (-sequence - 1)")
     self.class.where(table[:sequence].lt(0)).update_all("sequence = (-sequence)")

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -38,6 +38,26 @@ RSpec.describe Workflow, :type => :model do
     end
   end
 
+  describe '#save' do
+    let!(:old_sequence) { workflow.sequence }
+
+    context 'when sequence has new value' do
+      it 'updates with the new sequence' do
+        workflow.update(:sequence => old_sequence + 1)
+        workflow.reload
+        expect(workflow.sequence).to eq(old_sequence + 1)
+      end
+    end
+
+    context 'when sequence has not changed' do
+      it 'does not change sequence after save' do
+        workflow.update(:name => 'new_name')
+        workflow.reload
+        expect(workflow.sequence).to eq(old_sequence)
+      end
+    end
+  end
+
   context "with same name in different tenants" do
     let(:another_tenant) { create(:tenant) }
     let(:another_workflow) { create(:workflow, :name => workflow.name) }


### PR DESCRIPTION
We should not adjust sequences if current value does not change. Otherwise each save causes the numbers moving higher.

https://projects.engineering.redhat.com/browse/SSP-1536

The above ticket reported the problem occurs at GET. It is because each get does validation on  groups and save with updated group names.

It also resolves a warning on deprecated call.