### PR TITLE
Avoid gaps when adjust sequences

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -12,7 +12,8 @@ class Workflow < ApplicationRecord
   validates :sequence, :uniqueness => { scope: :tenant_id }
 
   before_validation :new_sequence, :on => :create
-  before_validation :move_rest_higher, :on => :update
+  before_validation :adjust_sequences, :on => :update
+  before_destroy    :sequence_lower
 
   def external_processing?
     template&.process_setting.present?
@@ -29,16 +30,54 @@ class Workflow < ApplicationRecord
   end
 
   def new_sequence
-    return move_rest_higher if sequence
+    throw :abort if sequence && sequence <= 0
 
-    self.sequence = self.class.last&.sequence.to_i + 1
+    largest = last_sequence
+    if sequence && sequence < last_sequence
+      sequence_higher(sequence)
+    else
+      self.sequence = largest + 1 # auto_assignment if sequence is nil or too large
+    end
   end
 
-  # move all related sequence number one higher if the desired number is in use
-  def move_rest_higher
-    return unless sequence && sequence_changed? && self.class.exists?(:sequence => sequence)
+  # no gap between sequences
+  def adjust_sequences
+    return unless sequence_changed?
 
-    self.class.where(table[:sequence].gteq(sequence)).update_all("sequence = (-sequence - 1)")
-    self.class.where(table[:sequence].lt(0)).update_all("sequence = (-sequence)")
+    throw :abort if sequence && sequence <= 0
+
+    largest = last_sequence
+    self.sequence = largest if sequence.nil? || sequence > largest
+
+    if sequence > sequence_was
+      sequence_lower(sequence_was, sequence)
+    else
+      sequence_higher(sequence, sequence_was)
+    end
+  end
+
+  # sequences increment between [sequence sequence_was sequence)
+  def sequence_higher(startp, endp = nil)
+    query = self.class.where(table[:sequence].gteq(startp))
+    query = query.where(table[:sequence].lteq(endp)) if endp
+    query.update_all("sequence = (-sequence - 1)")
+
+    query = self.class.where(table[:sequence].lt(0))
+    query = query.where.not(:sequence => -endp - 1) if endp # endp to be updated by rails
+    query.update_all("sequence = (-sequence)")
+  end
+
+  # sequences decrement between [startp endp]
+  def sequence_lower(startp = sequence, endp = nil)
+    query = self.class.where(table[:sequence].gteq(startp))
+    query = query.where(table[:sequence].lteq(endp)) if endp
+    query.update_all("sequence = (-sequence + 1)")
+
+    # startp to be updated by rails
+    query = self.class.where(table[:sequence].lt(0)).where.not(:sequence => -startp + 1).update_all("sequence = (-sequence)")
+  end
+
+  def last_sequence
+    self.class.last&.sequence.to_i
   end
 end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Workflow, :type => :model do
       expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
     end
 
-    it 'moves a worflows to the bottom' do
+    it 'moves a worflow to the bottom' do
       old_ids = Workflow.pluck(:id)
       Workflow.find(old_ids[3]).update(:sequence => nil)
       expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[1], old_ids[2], old_ids[4], old_ids[3]])
@@ -76,7 +76,7 @@ RSpec.describe Workflow, :type => :model do
       expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
     end
 
-    it 'fails to update non-positive sequence' do
+    it 'fails to update a 0 sequence' do
       expect { Workflow.first.update!(:sequence => 0) }.to raise_error(ActiveRecord::RecordInvalid)
     end
 

--- a/spec/support/tag_resources_shared_context.rb
+++ b/spec/support/tag_resources_shared_context.rb
@@ -1,11 +1,12 @@
 RSpec.shared_context "tag_resource_objects" do
   let(:tenant1) { create(:tenant) }
   let(:tenant2) { create(:tenant, :external_tenant => 'fred') }
-  let(:workflow1) { create(:workflow, :tenant => tenant1, :sequence => 10) }
+  let(:tenant1_workflows) { create_list(:workflow, 2, :tenant => tenant1) }
+  let(:workflow1) { tenant1_workflows[1] }
   let(:wf1_tag)   { "/approval/workflows=#{workflow1.id}" }
-  let(:workflow2) { create(:workflow, :tenant => tenant1, :sequence => 5) }
+  let(:workflow2) { tenant1_workflows[0] }
   let(:wf2_tag)   { "/approval/workflows=#{workflow2.id}" }
-  let(:workflow3) { create(:workflow, :tenant => tenant2, :sequence => 7) }
+  let(:workflow3) { create(:workflow, :tenant => tenant2) }
   let(:wf3_tag)   { "/approval/workflows=#{workflow3.id}" }
 
   let!(:tag_link1) { create(:tag_link, :tenant => tenant1, :app_name => 'catalog', :object_type => 'Portfolio', :tag_name => wf1_tag, :workflow => workflow1) }


### PR DESCRIPTION
A followup of #353 and #349 

Optimize the algorithm to avoid gaps when update the sequence.

User provided sequence may not be honored. It will be adjusted to the smallest available sequence if desired number is too large.