### PR TITLE
Retry building openapi-generator jar file

### DIFF
--- a/.travis_scripts/openapi-validator.sh
+++ b/.travis_scripts/openapi-validator.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
-set -e
+set -eu
+set -o pipefail
+
+if ! ./openapi-generator-cli version
+then
+  echo "openapi-generator-cli version failed, likely caused by a mvn build failure. Retry once."
+  ./openapi-generator-cli version
+fi
+
 for entry in ./public/doc/openapi-3-v*.json
 do
   ./openapi-generator-cli validate -i "$entry"
 done
-


### PR DESCRIPTION
Occasionally travis validation of openapi fails at building the openapi-generator-cli.jar. With this enhancement if the first validation attempt fails we will check whether the jar file exists. If not, we will start at re-downloading the script and run it again (retry once). 