### PR TITLE
Add checking on state of requests before deleting approval process

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -5,7 +5,7 @@ class Workflow < ApplicationRecord
   default_scope { order(:sequence => :asc) }
 
   belongs_to :template
-  before_destroy :validate_deletable, :pretend => true
+  before_destroy :validate_deletable, :prepend => true
   has_many :requests, -> { order(:id => :asc) }, :inverse_of => :workflow, :dependent => :nullify
   has_many :tag_links, :dependent => :destroy, :inverse_of => :workflow
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -6,6 +6,7 @@ class Workflow < ApplicationRecord
 
   belongs_to :template
   before_destroy :validate_deletable, :prepend => true
+  after_commit :send_deletion_message
   has_many :requests, -> { order(:id => :asc) }, :inverse_of => :workflow, :dependent => :nullify
   has_many :tag_links, :dependent => :destroy, :inverse_of => :workflow
 
@@ -47,6 +48,10 @@ class Workflow < ApplicationRecord
         dependencies[key] << value
       end
     end
+  end
+
+  def send_deletion_message
+    EventService.new(nil).workflow_deleted(id)
   end
 
   def table

--- a/app/policies/workflow_policy.rb
+++ b/app/policies/workflow_policy.rb
@@ -16,7 +16,7 @@ class WorkflowPolicy < ApplicationPolicy
   end
 
   def destroy?
-    permission_check('delete')
+    permission_check('delete') ? record.deletable? : false
   end
 
   def link?

--- a/app/services/event_service.rb
+++ b/app/services/event_service.rb
@@ -6,6 +6,7 @@ class EventService
   EVENT_REQUEST_CANCELED  = 'request_canceled'.freeze
   EVENT_APPROVER_GROUP_NOTIFIED = 'approver_group_notified'.freeze
   EVENT_APPROVER_GROUP_FINISHED = 'approver_group_finished'.freeze
+  EVENT_WORKFLOW_DELETED = 'workflow_deleted'.freeze
   EVENT_SENDER = 'approval_service'.freeze
 
   attr_accessor :request
@@ -32,6 +33,10 @@ class EventService
                :group_name => request.group_name,
                :decision   => request.decision,
                :reason     => request.reason || '')
+  end
+
+  def workflow_deleted(workflow_id)
+    send_event(EVENT_WORKFLOW_DELETED, :workflow_id => workflow_id)
   end
 
   # request is root

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -88,6 +88,71 @@ RSpec.describe Workflow, :type => :model do
     end
   end
 
+  describe '#deletable?' do
+    shared_examples_for "undeletable_states" do |state|
+      it "returns false for #{state}" do
+        request = create(:request, :workflow => workflow, :state => state)
+        expect(workflow.deletable?).to eq(false)
+      end
+    end
+    
+    shared_examples_for "deletable_states" do |state|
+      it "returns true for #{state}" do
+        request = create(:request, :workflow => workflow, :state => state)
+        expect(workflow.deletable?).to eq(true)
+      end
+    end
+
+    (Request::STATES - Request::FINISHED_STATES).each do |state|
+      it_behaves_like "undeletable_states", state
+    end
+
+    Request::FINISHED_STATES.each do |state|
+      it_behaves_like "deletable_states", state
+    end
+  end
+
+  describe '#destroy' do
+    let!(:taglink) { create(:tag_link, :workflow => workflow) }
+
+    context 'when without associated request' do
+      it 'deletes workflow' do
+        expect(TagLink.count).to eq(1)
+        workflow.destroy
+
+        expect(workflow).to be_destroyed
+        expect(TagLink.count).to eq(0)
+      end
+    end
+
+    context 'when associated with requests' do
+      it "is not deletable" do
+        allow(workflow).to receive(:deletable?).and_return(false)
+
+        request = create(:request, :workflow => workflow)
+
+        expect(TagLink.count).to eq(1)
+        expect { workflow.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+        expect(workflow).not_to be_destroyed
+        expect(request.workflow_id).to eq(workflow.id)
+        expect(TagLink.count).to eq(1)
+      end
+
+      it "is deletable" do
+        allow(workflow).to receive(:deletable?).and_return(true)
+
+        request = create(:request, :workflow => workflow)
+
+        expect(TagLink.count).to eq(1)
+        workflow.destroy
+        request.reload
+        expect(workflow).to be_destroyed
+        expect(request.workflow_id).to be_nil
+        expect(TagLink.count).to eq(0)
+      end
+    end
+  end
+
   context "with same name in different tenants" do
     let(:another_tenant) { create(:tenant) }
     let(:another_workflow) { create(:workflow, :name => workflow.name) }

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -91,14 +91,14 @@ RSpec.describe Workflow, :type => :model do
   describe '#deletable?' do
     shared_examples_for "undeletable_states" do |state|
       it "returns false for #{state}" do
-        request = create(:request, :workflow => workflow, :state => state)
+        create(:request, :workflow => workflow, :state => state)
         expect(workflow.deletable?).to eq(false)
       end
     end
-    
+
     shared_examples_for "deletable_states" do |state|
       it "returns true for #{state}" do
-        request = create(:request, :workflow => workflow, :state => state)
+        create(:request, :workflow => workflow, :state => state)
         expect(workflow.deletable?).to eq(true)
       end
     end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -126,6 +126,8 @@ RSpec.describe Workflow, :type => :model do
     end
 
     context 'when associated with requests' do
+      let(:event_service) { double('event_service') }
+
       it "is not deletable" do
         allow(workflow).to receive(:deletable?).and_return(false)
 
@@ -140,9 +142,11 @@ RSpec.describe Workflow, :type => :model do
 
       it "is deletable" do
         allow(workflow).to receive(:deletable?).and_return(true)
+        allow(EventService).to receive(:new).and_return(event_service)
 
-        request = create(:request, :workflow => workflow)
+        request = create(:request, :workflow => workflow, :state => Request::COMPLETED_STATE)
 
+        expect(event_service).to receive(:workflow_deleted)
         expect(TagLink.count).to eq(1)
         workflow.destroy
         request.reload

--- a/spec/policies/workflow_policy_spec.rb
+++ b/spec/policies/workflow_policy_spec.rb
@@ -63,6 +63,25 @@ describe WorkflowPolicy do
 
       expect(subject.user_capabilities).to eq(result)
     end
+
+    context 'when workflow is undeletable' do
+      before { allow(workflow).to receive(:deletable?).and_return(false) }
+
+      it 'returns false on #destroy?' do
+        expect(subject.destroy?).to be_falsey
+      end
+
+      it 'returns false on #destroy in user capabilities' do
+        result = { "create"=>true,
+                   "destroy"=>false,
+                   "link"=>true,
+                   "show"=>true,
+                   "unlink"=>true,
+                   "update"=>true }
+
+        expect(subject.user_capabilities).to eq(result)
+      end
+    end
   end
 
   describe 'with approver role' do

--- a/spec/policies/workflow_policy_spec.rb
+++ b/spec/policies/workflow_policy_spec.rb
@@ -72,12 +72,12 @@ describe WorkflowPolicy do
       end
 
       it 'returns false on #destroy in user capabilities' do
-        result = { "create"=>true,
-                   "destroy"=>false,
-                   "link"=>true,
-                   "show"=>true,
-                   "unlink"=>true,
-                   "update"=>true }
+        result = {"create"  => true,
+                  "destroy" => false,
+                  "link"    => true,
+                  "show"    => true,
+                  "unlink"  => true,
+                  "update"  => true}
 
         expect(subject.user_capabilities).to eq(result)
       end

--- a/spec/services/event_service_spec.rb
+++ b/spec/services/event_service_spec.rb
@@ -26,4 +26,9 @@ RSpec.describe EventService do
     expect(subject).to receive(:send_event).with(described_class::EVENT_APPROVER_GROUP_FINISHED, hash_including(:request_id, :group_name, :decision, :reason))
     subject.approver_group_finished
   end
+
+  it 'sends workflow_deleted event' do
+    expect(subject).to receive(:send_event).with(described_class::EVENT_WORKFLOW_DELETED, hash_including(:workflow_id))
+    subject.workflow_deleted(1)
+  end
 end


### PR DESCRIPTION
In this PR, workflow is forbid to delete if one of its associated requests is still running: (state is `pending`, `started` or `notified`). Try to delete such a workflow will raise an error. 

Workflow will allow to be deleted If all its associated requests are completed. After workflow is deleted, the foreign key `workflow_id` of these completed requests will set to `nil`.

Whenever the workflow is deleted, the associated `TagLinks` will always be removed too. 

https://projects.engineering.redhat.com/browse/SSP-1544