### PR TITLE
Prevent workflow sequence from becoming negative

### DIFF
--- a/app/controllers/api/v1x2/workflows_controller.rb
+++ b/app/controllers/api/v1x2/workflows_controller.rb
@@ -34,7 +34,7 @@ module Api
         workflow = Workflow.find(params.require(:id))
         authorize workflow
 
-        workflow.destroy!
+        WorkflowDeleteService.new(params[:id]).destroy
         head :no_content
       rescue ActiveRecord::InvalidForeignKey => e
         json_response({ :message => e.message }, :forbidden)

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -13,7 +13,9 @@ class Workflow < ApplicationRecord
 
   before_validation :new_sequence, :on => :create
   before_validation :adjust_sequences, :on => :update
+  after_save        :validate_positive_sequences
   before_destroy    :sequence_lower
+  after_destroy     :validate_positive_sequences
 
   def external_processing?
     template&.process_setting.present?
@@ -82,5 +84,9 @@ class Workflow < ApplicationRecord
 
   def last_sequence
     self.class.last&.sequence.to_i
+  end
+
+  def validate_positive_sequences
+    raise Exceptions::NegativeSequence if self.class.where(table[:sequence].lteq(0)).exists?
   end
 end

--- a/app/services/workflow_delete_service.rb
+++ b/app/services/workflow_delete_service.rb
@@ -1,0 +1,17 @@
+class WorkflowDeleteService
+  attr_accessor :workflow_id
+
+  def initialize(workflow_id)
+    self.workflow_id = workflow_id
+  end
+
+  def destroy
+    begin
+      retries ||= 0
+      Workflow.find(workflow_id).destroy!
+    rescue ActiveRecord::RecordNotUnique, Exceptions::NegativeSequence # Failed to update sequence after deletion due to concurrent issue
+      retry if (retries += 1) < 3
+    end
+  end
+
+end

--- a/app/services/workflow_update_service.rb
+++ b/app/services/workflow_update_service.rb
@@ -2,10 +2,10 @@ require_relative 'mixins/group_validate_mixin'
 
 class WorkflowUpdateService
   include GroupValidateMixin
-  attr_accessor :workflow
+  attr_accessor :workflow_id
 
   def initialize(workflow_id)
-    self.workflow = Workflow.find(workflow_id)
+    self.workflow_id = workflow_id
   end
 
   def update(options)
@@ -14,9 +14,9 @@ class WorkflowUpdateService
     end
 
     begin
-      retries ||=0
-      workflow.update!(options)
-    rescue ActiveRecord::RecordNotUnique # Sequence numbers may be found duplicated due to concurrent issue
+      retries ||= 0
+      Workflow.find(workflow_id).update!(options)
+    rescue ActiveRecord::RecordNotUnique, Exceptions::NegativeSequence # Sequence numbers may be found duplicated due to concurrent issue
       retry if (retries += 1) < 3
     end
   end

--- a/config/initializers/custom_exception_mappings.rb
+++ b/config/initializers/custom_exception_mappings.rb
@@ -2,8 +2,10 @@
 ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
   "ActiveRecord::RecordNotSaved"               => :bad_request,
   "ActiveRecord::RecordInvalid"                => :bad_request,
+  "ActiveRecord::RecordNotUnique"              => :bad_request,
   "ActionController::ParameterMissing"         => :bad_request,
   "Exceptions::InvalidStateTransitionError"    => :bad_request,
+  "Exceptions::NegativeSequenceError"          => :bad_request,
   "Exceptions::UserError"                      => :bad_request,
   "Exceptions::NotAuthorizedError"             => :forbidden,
   "Pundit::NotAuthorizedError"                 => :forbidden,

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -6,4 +6,5 @@ module Exceptions
   class KieError < StandardError; end
   class InvalidStateTransitionError < StandardError; end
   class UserError < StandardError; end
+  class NegativeSequence < StandardError; end
 end

--- a/spec/services/workflow_delete_service_spec.rb
+++ b/spec/services/workflow_delete_service_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe WorkflowDeleteService do
+  let(:workflows) { create_list(:workflow, 5) }
+
+  it 'deletes multiple sequences' do
+    Thread.abort_on_exception = true
+    trs = workflows.collect do |wf|
+      Thread.new do
+        described_class.new(wf.id).destroy
+      end
+    end
+    trs.each { |t| t.join }
+    expect(Workflow.count).to be_zero
+  end
+end


### PR DESCRIPTION
Validate sequence to be all positive after save or destroy. Introduce `WorkflowDeleteService` class.

https://projects.engineering.redhat.com/browse/SSP-1567

It as been reported that the workflow sequence sometimes can become negative. It can be reproduced by simultaneously deleting multiple workflows.

Before updating or destroying a workflow, we adjust sequences for other workflows and leave the current workflow's sequence number to be negative and allow it to be updated or destroyed through the AR's built-in process. But in a concurrent situation we may identify the wrong sequence number and leave a negative sequence un-updated.

The solution is to add validation in the `after_save` or `after_destroy` callbacks to ensure no negative sequence number is ever allowed. Transaction rolls back if the validation fails. We then retry the operation using the reloaded record.
