### PR TITLE
Separate errors of external services into more detailed categories

### DIFF
--- a/app/services/remote_tagging_service.rb
+++ b/app/services/remote_tagging_service.rb
@@ -6,6 +6,7 @@ class RemoteTaggingService
   # TODO: Support proper pagination of tags from Faraday since
   # we are not using the generated client here.
   QUERY_LIMIT = 1000
+
   def initialize(options)
     @app_name = options[:app_name]
     @object_type = options[:object_type]
@@ -46,7 +47,7 @@ class RemoteTaggingService
 
   def service_url
     match = self.class.remotes.detect { |item| item[:app_name] == @app_name && item[:object_type] == @object_type }
-    raise "No url found for app #{@app_name} object #{@object_type}" unless match
+    raise Exceptions::InvalidURLError.new("No url found for app #{@app_name} object #{@object_type}") unless match
 
     match[:url].call
   end
@@ -75,7 +76,7 @@ class RemoteTaggingService
     if response.status == 403
       raise Exceptions::NotAuthorizedError, response.reason_phrase
     else
-      raise "#{message_prefix} #{response.reason_phrase}" unless VALID_HTTP_CODES.include?(response.status)
+      raise Exceptions::TaggingError.new("#{message_prefix} #{response.reason_phrase}") unless VALID_HTTP_CODES.include?(response.status)
     end
   end
 

--- a/app/services/remote_tagging_service.rb
+++ b/app/services/remote_tagging_service.rb
@@ -2,7 +2,6 @@ require 'faraday'
 require_relative 'mixins/tag_mixin'
 class RemoteTaggingService
   include TagMixin
-  VALID_HTTP_CODES = [200, 201, 202, 204, 304].freeze
   # TODO: Support proper pagination of tags from Faraday since
   # we are not using the generated client here.
   QUERY_LIMIT = 1000
@@ -47,37 +46,41 @@ class RemoteTaggingService
 
   def service_url
     match = self.class.remotes.detect { |item| item[:app_name] == @app_name && item[:object_type] == @object_type }
-    raise Exceptions::InvalidURLError.new("No url found for app #{@app_name} object #{@object_type}") unless match
+    raise Exceptions::UserError.new("No url found for app #{@app_name} object #{@object_type}") unless match
 
     match[:url].call
   end
 
   def post_request(url, tags)
-    con = Faraday.new
-    response = con.post(url) do |session|
-      session.headers['Content-Type'] = 'application/json'
-      headers(session)
-      session.body = tags.to_json
+    call_remote_service do |con|
+      con.post(url) do |session|
+        session.headers['Content-Type'] = 'application/json'
+        headers(session)
+        session.body = tags.to_json
+      end
     end
-    check_for_exceptions(response, "Error posting tags")
   end
 
   def get_request(url, params)
-    con = Faraday.new
-    response = con.get(url) do |session|
-      headers(session)
-      params.each { |k, v| session.params[k] = v }
+    call_remote_service do |con|
+      con.get(url) do |session|
+        headers(session)
+        params.each { |k, v| session.params[k] = v }
+      end
     end
-    check_for_exceptions(response, "Error getting tags")
-    response
   end
 
-  def check_for_exceptions(response, message_prefix)
-    if response.status == 403
-      raise Exceptions::NotAuthorizedError, response.reason_phrase
-    else
-      raise Exceptions::TaggingError.new("#{message_prefix} #{response.reason_phrase}") unless VALID_HTTP_CODES.include?(response.status)
-    end
+  def call_remote_service
+    connection = Faraday.new
+    yield(connection)
+  rescue Faraday::TimeoutError => e
+    raise Exceptions::TimedOutError, e.message
+  rescue Faraday::ConnectionFailed => e
+    raise Exceptions::NetworkError, e.message
+  rescue Faraday::UnauthorizedError => e
+    raise Exceptions::NotAuthorizedError, e.message
+  rescue Faraday::Error => e
+    raise Exceptions::TaggingError, e.message
   end
 
   def headers(session)

--- a/config/initializers/custom_exception_mappings.rb
+++ b/config/initializers/custom_exception_mappings.rb
@@ -7,10 +7,14 @@ ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
   "Exceptions::InvalidStateTransitionError"    => :bad_request,
   "Exceptions::NegativeSequenceError"          => :bad_request,
   "Exceptions::UserError"                      => :bad_request,
+  "Exceptions::KieError"                       => :bad_request,
+  "Exceptions::InvalidURLError"                => :bad_request,
+  "Exceptions::TaggingError"                   => :bad_request,
   "Exceptions::NotAuthorizedError"             => :forbidden,
   "Pundit::NotAuthorizedError"                 => :forbidden,
   "Exceptions::RBACError"                      => :service_unavailable,
-  "Exceptions::KieError"                       => :service_unavailable,
+  "Exceptions::NetworkError"                   => :service_unavailable,
+  "Exceptions::TimedOutError"                  => :service_unavailable,
   "Insights::API::Common::RBAC::NetworkError"  => :service_unavailable,
   "Insights::API::Common::RBAC::TimedOutError" => :service_unavailable
 )

--- a/config/initializers/custom_exception_mappings.rb
+++ b/config/initializers/custom_exception_mappings.rb
@@ -8,7 +8,6 @@ ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
   "Exceptions::NegativeSequenceError"          => :bad_request,
   "Exceptions::UserError"                      => :bad_request,
   "Exceptions::KieError"                       => :bad_request,
-  "Exceptions::InvalidURLError"                => :bad_request,
   "Exceptions::TaggingError"                   => :bad_request,
   "Exceptions::NotAuthorizedError"             => :forbidden,
   "Pundit::NotAuthorizedError"                 => :forbidden,

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -7,4 +7,7 @@ module Exceptions
   class InvalidStateTransitionError < StandardError; end
   class UserError < StandardError; end
   class NegativeSequence < StandardError; end
+  class TaggingError < StandardError; end
+  class NetworkError < StandardError; end
+  class TimedOutError < StandardError; end
 end

--- a/lib/kie/service.rb
+++ b/lib/kie/service.rb
@@ -6,6 +6,9 @@ module Kie
       yield init(klass)
     rescue KieClient::ApiError => err
       Rails.logger.error("KieClient::ApiError #{err.message} ")
+
+      raise Exceptions::TimedOutError.new('Connection timed out') if err.code.nil?
+      raise Exceptions::NetworkError.new(err.message) if err.code.zero?
       raise Exceptions::KieError, "KieClient::ApiError: #{err.message}"
     end
 

--- a/spec/lib/kie/service_spec.rb
+++ b/spec/lib/kie/service_spec.rb
@@ -1,5 +1,7 @@
 describe Kie::Service do
-  let(:kie_ex) { KieClient::ApiError.new("kie_error") }
+  let(:kie_ex) { KieClient::ApiError.new(:message => "kie_error", :code => 1) }
+  let(:kie_nil_ex) { KieClient::ApiError.new("kie_error") }
+  let(:kie_zero_ex) { KieClient::ApiError.new(:messsage => "kie_error", :code => 0) }
   let(:options) { {} }
 
   describe '.call' do
@@ -9,6 +11,18 @@ describe Kie::Service do
           raise kie_ex
         end
       end.to raise_exception(Exceptions::KieError)
+
+      expect do
+        described_class.call(KieClient::ProcessInstancesBPMApi, options) do |_api|
+          raise kie_nil_ex
+        end
+      end.to raise_exception(Exceptions::TimedOutError)
+
+      expect do
+        described_class.call(KieClient::ProcessInstancesBPMApi, options) do |_api|
+          raise kie_zero_ex
+        end
+      end.to raise_exception(Exceptions::NetworkError)
     end
   end
 

--- a/spec/services/add_remote_tags_spec.rb
+++ b/spec/services/add_remote_tags_spec.rb
@@ -27,12 +27,9 @@ RSpec.describe AddRemoteTags, :type => :request do
 
   # .with(:body => approval_tag.to_json, :headers => headers)
   shared_examples_for '#test_all' do
-    before do
-      stub_request(:post, url)
-        .to_return(:status => http_status, :body => approval_tags.to_json, :headers => headers)
-    end
-
     it 'adds a remote tag' do
+      stub_request(:post, url).to_return(:status => http_status, :body => approval_tags.to_json, :headers => headers)
+
       with_modified_env test_env do
         subject.process(approval_tags)
       end
@@ -42,21 +39,35 @@ RSpec.describe AddRemoteTags, :type => :request do
       expect { subject.process(approval_tags) }.to raise_error(RuntimeError, env_not_set)
     end
 
-    context "raises error" do
-      let(:http_status) { [404, 'Bad Request'] }
-      it 'raises an error if the status is not 200' do
-        with_modified_env test_env do
-          expect { subject.process(approval_tags) }.to raise_error(Exceptions::TaggingError, /Error posting tags/)
-        end
+    it "raises tagging error" do
+      stub_request(:post, url).to_raise(Faraday::BadRequestError)
+
+      with_modified_env test_env do
+        expect { subject.process(approval_tags) }.to raise_error(Exceptions::TaggingError)
       end
     end
 
-    context "raises authentication error" do
-      let(:http_status) { [403, 'Authentication Error'] }
-      it 'raises an error if the status is 403' do
-        with_modified_env test_env do
-          expect { subject.process(approval_tags) }.to raise_error(Exceptions::NotAuthorizedError, /Authentication Error/)
-        end
+    it "raises authentication error" do
+      stub_request(:post, url).to_raise(Faraday::UnauthorizedError)
+
+      with_modified_env test_env do
+        expect { subject.process(approval_tags) }.to raise_error(Exceptions::NotAuthorizedError)
+      end
+    end
+
+    it "raises network error" do
+      stub_request(:post, url).to_raise(Faraday::ConnectionFailed)
+
+      with_modified_env test_env do
+        expect { subject.process(approval_tags) }.to raise_error(Exceptions::NetworkError)
+      end
+    end
+
+    it "raises timeout error" do
+      stub_request(:post, url).to_raise(Faraday::TimeoutError)
+
+      with_modified_env test_env do
+        expect { subject.process(approval_tags) }.to raise_error(Exceptions::TimedOutError)
       end
     end
   end

--- a/spec/services/add_remote_tags_spec.rb
+++ b/spec/services/add_remote_tags_spec.rb
@@ -15,11 +15,6 @@ RSpec.describe AddRemoteTags, :type => :request do
     { 'Content-Type' => 'application/json' }.merge(default_headers)
   end
 
-  let(:remote_tags) do
-    [{:tag => '/Charkie/Gnocchi=Hundley'},
-     {:tag => '/Curious George/Jumpy Squirrel=Compass'}]
-  end
-
   let(:test_env) do
     {
       :TOPOLOGICAL_INVENTORY_URL => 'http://localhost',
@@ -51,7 +46,7 @@ RSpec.describe AddRemoteTags, :type => :request do
       let(:http_status) { [404, 'Bad Request'] }
       it 'raises an error if the status is not 200' do
         with_modified_env test_env do
-          expect { subject.process(approval_tags) }.to raise_error(RuntimeError, /Error posting tags/)
+          expect { subject.process(approval_tags) }.to raise_error(Exceptions::TaggingError, /Error posting tags/)
         end
       end
     end

--- a/spec/services/delete_remote_tags_spec.rb
+++ b/spec/services/delete_remote_tags_spec.rb
@@ -14,11 +14,6 @@ RSpec.describe DeleteRemoteTags, :type => :request do
     { 'Content-Type' => 'application/json' }.merge(default_headers)
   end
 
-  let(:remote_tags) do
-    [{:tag => '/Charkie/Gnocchi=Hundley'},
-     {:tag => '/Curious George/Jumpy Squirrel=Compass'}]
-  end
-
   let(:test_env) do
     {
       :TOPOLOGICAL_INVENTORY_URL => 'http://localhost',
@@ -49,7 +44,7 @@ RSpec.describe DeleteRemoteTags, :type => :request do
       let(:http_status) { [404, 'Bad Request'] }
       it 'raises an error if the status is not 200' do
         with_modified_env test_env do
-          expect { subject.process(approval_tags) }.to raise_error(RuntimeError, /Error posting tags/)
+          expect { subject.process(approval_tags) }.to raise_error(Exceptions::TaggingError, /Error posting tags/)
         end
       end
     end

--- a/spec/services/get_remote_tags_spec.rb
+++ b/spec/services/get_remote_tags_spec.rb
@@ -5,9 +5,6 @@ RSpec.describe GetRemoteTags, :type => :request do
 
   let(:object_id) { '123' }
   let(:options) { {:object_type => object_type, :app_name => app_name, :object_id => object_id} }
-  let(:approval_tag) do
-    { :tag => "/#{WorkflowLinkService::TAG_NAMESPACE}/#{WorkflowLinkService::TAG_NAME}=100" }
-  end
   let(:app_name) { 'catalog' }
   let(:object_type) { 'Portfolio' }
   let(:url) { "http://localhost/api/catalog/v1.0/portfolios/#{object_id}/tags?limit=1000" }
@@ -30,7 +27,7 @@ RSpec.describe GetRemoteTags, :type => :request do
 
   subject { described_class.new(options) }
 
-  context 'get tags' do
+  describe 'get tags' do
     before do
       stub_request(:get, url)
         .to_return(:status => http_status, :body => {:data => remote_tags}.to_json, :headers => default_headers)
@@ -39,6 +36,16 @@ RSpec.describe GetRemoteTags, :type => :request do
     it 'successfully fetches tags' do
       with_modified_env test_env do
         expect(subject.process.tags).to match([tag1_string, tag2_string])
+      end
+    end
+
+    context 'with invalid object_type' do
+      let(:object_type) { 'InvalidObjectType' }
+
+      it 'raises an error' do
+        with_modified_env test_env do
+          expect { subject.process }.to raise_error(Exceptions::InvalidURLError, /No url found/)
+        end
       end
     end
   end
@@ -52,7 +59,7 @@ RSpec.describe GetRemoteTags, :type => :request do
 
     it 'raises error' do
       with_modified_env test_env do
-        expect { subject.process }.to raise_error(RuntimeError, /Not found/)
+        expect { subject.process }.to raise_error(Exceptions::TaggingError, /Not found/)
       end
     end
   end

--- a/spec/support/tag_resources_shared_context.rb
+++ b/spec/support/tag_resources_shared_context.rb
@@ -22,10 +22,6 @@ RSpec.shared_context "tag_resource_objects" do
     { :tag => "/#{WorkflowLinkService::TAG_NAMESPACE}/#{WorkflowLinkService::TAG_NAME}=#{workflow2.id}" }
   end
 
-  let(:tag3) do
-    { :tag => "/#{WorkflowLinkService::TAG_NAMESPACE}/#{WorkflowLinkService::TAG_NAME}=#{workflow3.id}" }
-  end
-
   let(:bogus_tag) do
     { :tag => '/curious/george=gnocchi' }
   end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1301

In this PR:
1. Separated `NetworkError` and `TimedOutError` from common `KieError` for PAM service;
2. Separated `NetworkError`, `TimedOutError` and `NotAuthorizedError` from `Faraday` exceptions, marked other errors as `TaggingError`, for remote tagging services