### PR TITLE
Bump puma to v4.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'manageiq-loggers',    '~> 0.2'
 gem 'manageiq-messaging',  '~> 0.1'
 gem 'pg',                  '~> 1.0', :require => false
 gem 'prometheus-client',   '~> 0.8.0'
-gem 'puma',                '~> 3.12.6'
+gem 'puma',                '>= 4.3.5'
 gem 'pundit'
 gem 'rack-cors',           '>= 1.0.4'
 gem 'rails',               '>= 5.2.2.1', '~> 5.2.2'
@@ -26,8 +26,8 @@ group :development, :test do
 end
 
 group :test do
-  gem 'factory_bot_rails', '~> 4.0'
+  gem 'factory_bot_rails'
   gem 'faker'
-  gem 'rspec-rails', '~> 3.5'
+  gem 'rspec-rails'
   gem 'shoulda-matchers', '~> 3.1'
 end


### PR DESCRIPTION
Noticed we were lagging behind the other services with the puma version. This version also addresses recent vulnerabilities.

Also dropped version from test gems factory_bot_rails and rspec-rails.

Matching
https://github.com/RedHatInsights/topological_inventory-api/blob/master/Gemfile#L16
https://github.com/RedHatInsights/catalog-api/pull/758