### PR TITLE
[Stable] Prevent workflow sequence from becoming negative

### DIFF
--- a/app/controllers/api/v1x2/workflows_controller.rb
+++ b/app/controllers/api/v1x2/workflows_controller.rb
@@ -34,7 +34,7 @@ module Api
         workflow = Workflow.find(params.require(:id))
         authorize workflow
 
-        workflow.destroy!
+        WorkflowDeleteService.new(params[:id]).destroy
         head :no_content
       rescue ActiveRecord::InvalidForeignKey => e
         json_response({ :message => e.message }, :forbidden)

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -13,7 +13,9 @@ class Workflow < ApplicationRecord
 
   before_validation :new_sequence, :on => :create
   before_validation :adjust_sequences, :on => :update
+  after_save        :validate_positive_sequences
   before_destroy    :sequence_lower
+  after_destroy     :validate_positive_sequences
 
   def external_processing?
     template&.process_setting.present?
@@ -82,5 +84,9 @@ class Workflow < ApplicationRecord
 
   def last_sequence
     self.class.last&.sequence.to_i
+  end
+
+  def validate_positive_sequences
+    raise Exceptions::NegativeSequence if self.class.where(table[:sequence].lteq(0)).exists?
   end
 end

--- a/app/services/workflow_create_service.rb
+++ b/app/services/workflow_create_service.rb
@@ -15,7 +15,7 @@ class WorkflowCreateService
       retries ||= 0
       template.workflows.create!(options)
     rescue ActiveRecord::RecordNotUnique # The auto generated sequence number may be found duplicated due to concurrent issue
-      retry if (retries += 1) < 3
+      (retries += 1) < 3 ? retry : raise
     end
   end
 end

--- a/app/services/workflow_delete_service.rb
+++ b/app/services/workflow_delete_service.rb
@@ -1,0 +1,17 @@
+class WorkflowDeleteService
+  attr_accessor :workflow_id
+
+  def initialize(workflow_id)
+    self.workflow_id = workflow_id
+  end
+
+  def destroy
+    begin
+      retries ||= 0
+      Workflow.find(workflow_id).destroy!
+    rescue ActiveRecord::RecordNotUnique, Exceptions::NegativeSequence # Failed to update sequence after deletion due to concurrent issue
+      retry if (retries += 1) < 3
+    end
+  end
+
+end

--- a/app/services/workflow_delete_service.rb
+++ b/app/services/workflow_delete_service.rb
@@ -10,7 +10,7 @@ class WorkflowDeleteService
       retries ||= 0
       Workflow.find(workflow_id).destroy!
     rescue ActiveRecord::RecordNotUnique, Exceptions::NegativeSequence # Failed to update sequence after deletion due to concurrent issue
-      retry if (retries += 1) < 3
+      (retries += 1) < 3 ? retry : raise
     end
   end
 

--- a/app/services/workflow_update_service.rb
+++ b/app/services/workflow_update_service.rb
@@ -2,10 +2,10 @@ require_relative 'mixins/group_validate_mixin'
 
 class WorkflowUpdateService
   include GroupValidateMixin
-  attr_accessor :workflow
+  attr_accessor :workflow_id
 
   def initialize(workflow_id)
-    self.workflow = Workflow.find(workflow_id)
+    self.workflow_id = workflow_id
   end
 
   def update(options)
@@ -14,9 +14,9 @@ class WorkflowUpdateService
     end
 
     begin
-      retries ||=0
-      workflow.update!(options)
-    rescue ActiveRecord::RecordNotUnique # Sequence numbers may be found duplicated due to concurrent issue
+      retries ||= 0
+      Workflow.find(workflow_id).update!(options)
+    rescue ActiveRecord::RecordNotUnique, Exceptions::NegativeSequence # Sequence numbers may be found duplicated due to concurrent issue
       retry if (retries += 1) < 3
     end
   end

--- a/app/services/workflow_update_service.rb
+++ b/app/services/workflow_update_service.rb
@@ -17,7 +17,7 @@ class WorkflowUpdateService
       retries ||= 0
       Workflow.find(workflow_id).update!(options)
     rescue ActiveRecord::RecordNotUnique, Exceptions::NegativeSequence # Sequence numbers may be found duplicated due to concurrent issue
-      retry if (retries += 1) < 3
+      (retries += 1) < 3 ? retry : raise
     end
   end
 end

--- a/config/initializers/custom_exception_mappings.rb
+++ b/config/initializers/custom_exception_mappings.rb
@@ -2,8 +2,10 @@
 ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
   "ActiveRecord::RecordNotSaved"               => :bad_request,
   "ActiveRecord::RecordInvalid"                => :bad_request,
+  "ActiveRecord::RecordNotUnique"              => :bad_request,
   "ActionController::ParameterMissing"         => :bad_request,
   "Exceptions::InvalidStateTransitionError"    => :bad_request,
+  "Exceptions::NegativeSequenceError"          => :bad_request,
   "Exceptions::UserError"                      => :bad_request,
   "Exceptions::NotAuthorizedError"             => :forbidden,
   "Pundit::NotAuthorizedError"                 => :forbidden,

--- a/config/initializers/custom_exception_mappings.rb
+++ b/config/initializers/custom_exception_mappings.rb
@@ -5,7 +5,7 @@ ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
   "ActiveRecord::RecordNotUnique"              => :bad_request,
   "ActionController::ParameterMissing"         => :bad_request,
   "Exceptions::InvalidStateTransitionError"    => :bad_request,
-  "Exceptions::NegativeSequenceError"          => :bad_request,
+  "Exceptions::NegativeSequence"               => :bad_request,
   "Exceptions::UserError"                      => :bad_request,
   "Exceptions::NotAuthorizedError"             => :forbidden,
   "Pundit::NotAuthorizedError"                 => :forbidden,

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -6,4 +6,5 @@ module Exceptions
   class KieError < StandardError; end
   class InvalidStateTransitionError < StandardError; end
   class UserError < StandardError; end
+  class NegativeSequence < StandardError; end
 end

--- a/spec/config/initializers/custom_exception_mappings_spec.rb
+++ b/spec/config/initializers/custom_exception_mappings_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe ActionDispatch::ExceptionWrapper do
+  let(:status_symbols) { Rack::Utils::SYMBOL_TO_STATUS_CODE.keys }
+
+  it 'maps an error class to a valid http status symbol' do
+    described_class.rescue_responses.each do |key, value|
+      expect(key.constantize).to be_truthy
+      expect(status_symbols).to include(value)
+    end
+  end
+end

--- a/spec/controllers/v1.2/workflows_controller_spec.rb
+++ b/spec/controllers/v1.2/workflows_controller_spec.rb
@@ -385,6 +385,19 @@ RSpec.describe Api::V1x2::WorkflowsController, :type => [:request, :v1x2] do
 
         expect(response).to have_http_status(204)
       end
+
+      context 'when negative sequence may be resulted' do
+        before do
+          allow(Workflow).to receive(:find).with(id.to_s).and_return(workflows[0])
+          allow(workflows[0]).to receive(:validate_positive_sequences).and_raise(Exceptions::NegativeSequence)
+        end
+
+        it 'returns status code 400' do
+          delete "#{api_version}/workflows/#{id}", :headers => default_headers
+
+          expect(response).to have_http_status(400)
+        end
+      end
     end
 
     context 'approver role when delete' do

--- a/spec/services/workflow_delete_service_spec.rb
+++ b/spec/services/workflow_delete_service_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe WorkflowDeleteService do
+  let(:workflows) { create_list(:workflow, 5) }
+
+  it 'deletes multiple sequences' do
+    Thread.abort_on_exception = true
+    trs = workflows.collect do |wf|
+      Thread.new do
+        described_class.new(wf.id).destroy
+      end
+    end
+    trs.each { |t| t.join }
+    expect(Workflow.count).to be_zero
+  end
+end


### PR DESCRIPTION
cherry-pick changes from #367 and #372

>Validate sequence to be all positive after save or destroy. Introduce WorkflowDeleteService class.
>
>https://projects.engineering.redhat.com/browse/SSP-1567
>
>It as been reported that the workflow sequence sometimes can become negative. It can be reproduced by simultaneously deleting multiple workflows.
>
>Before updating or destroying a workflow, we adjust sequences for other workflows and leave the current workflow's sequence number to be negative and allow it to be updated or destroyed through the AR's built-in process. But in a concurrent situation we may identify the wrong sequence number and leave a negative sequence un-updated.
>
>The solution is to add validation in the after_save or after_destroy callbacks to ensure no negative sequence number is ever allowed. Transaction rolls back if the validation fails. We then retry the operation using the reloaded record.