### PR TITLE
Fix mis-spelled error class name

### DIFF
--- a/app/services/workflow_create_service.rb
+++ b/app/services/workflow_create_service.rb
@@ -15,7 +15,7 @@ class WorkflowCreateService
       retries ||= 0
       template.workflows.create!(options)
     rescue ActiveRecord::RecordNotUnique # The auto generated sequence number may be found duplicated due to concurrent issue
-      retry if (retries += 1) < 3
+      (retries += 1) < 3 ? retry : raise
     end
   end
 end

--- a/app/services/workflow_delete_service.rb
+++ b/app/services/workflow_delete_service.rb
@@ -10,7 +10,7 @@ class WorkflowDeleteService
       retries ||= 0
       Workflow.find(workflow_id).destroy!
     rescue ActiveRecord::RecordNotUnique, Exceptions::NegativeSequence # Failed to update sequence after deletion due to concurrent issue
-      retry if (retries += 1) < 3
+      (retries += 1) < 3 ? retry : raise
     end
   end
 

--- a/app/services/workflow_update_service.rb
+++ b/app/services/workflow_update_service.rb
@@ -17,7 +17,7 @@ class WorkflowUpdateService
       retries ||= 0
       Workflow.find(workflow_id).update!(options)
     rescue ActiveRecord::RecordNotUnique, Exceptions::NegativeSequence # Sequence numbers may be found duplicated due to concurrent issue
-      retry if (retries += 1) < 3
+      (retries += 1) < 3 ? retry : raise
     end
   end
 end

--- a/config/initializers/custom_exception_mappings.rb
+++ b/config/initializers/custom_exception_mappings.rb
@@ -5,7 +5,7 @@ ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
   "ActiveRecord::RecordNotUnique"              => :bad_request,
   "ActionController::ParameterMissing"         => :bad_request,
   "Exceptions::InvalidStateTransitionError"    => :bad_request,
-  "Exceptions::NegativeSequenceError"          => :bad_request,
+  "Exceptions::NegativeSequence"               => :bad_request,
   "Exceptions::UserError"                      => :bad_request,
   "Exceptions::NotAuthorizedError"             => :forbidden,
   "Pundit::NotAuthorizedError"                 => :forbidden,

--- a/spec/config/initializers/custom_exception_mappings_spec.rb
+++ b/spec/config/initializers/custom_exception_mappings_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe ActionDispatch::ExceptionWrapper do
+  let(:status_symbols) { Rack::Utils::SYMBOL_TO_STATUS_CODE.keys }
+
+  it 'maps an error class to a valid http status symbol' do
+    described_class.rescue_responses.each do |key, value|
+      expect(key.constantize).to be_truthy
+      expect(status_symbols).to include(value)
+    end
+  end
+end

--- a/spec/controllers/v1.2/workflows_controller_spec.rb
+++ b/spec/controllers/v1.2/workflows_controller_spec.rb
@@ -385,6 +385,19 @@ RSpec.describe Api::V1x2::WorkflowsController, :type => [:request, :v1x2] do
 
         expect(response).to have_http_status(204)
       end
+
+      context 'when negative sequence may be resulted' do
+        before do
+          allow(Workflow).to receive(:find).with(id.to_s).and_return(workflows[0])
+          allow(workflows[0]).to receive(:validate_positive_sequences).and_raise(Exceptions::NegativeSequence)
+        end
+
+        it 'returns status code 400' do
+          delete "#{api_version}/workflows/#{id}", :headers => default_headers
+
+          expect(response).to have_http_status(400)
+        end
+      end
     end
 
     context 'approver role when delete' do


### PR DESCRIPTION
We renamed an error class name in #367 that needs to be changed in the error conversion list. 