### PR TITLE
Rescue Active::DeadLocked error and retry

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -71,13 +71,13 @@ class Workflow < ApplicationRecord
   end
 
   def change_sequences_to_negative(startp, endp, delta)
-    query = self.class.where(table[:sequence].gteq(startp))
+    query = self.class.reorder(:id).where(table[:sequence].gteq(startp))
     query = query.where(table[:sequence].lteq(endp)) if endp
     query.update_all(["sequence = (-sequence + (?))", delta])
   end
 
   def change_sequences_to_positive(exceptp)
-    query = self.class.where(table[:sequence].lt(0))
+    query = self.class.reorder(:id).where(table[:sequence].lt(0))
     query = query.where.not(:sequence => exceptp) if exceptp
     query.update_all("sequence = (-sequence)")
   end
@@ -87,6 +87,6 @@ class Workflow < ApplicationRecord
   end
 
   def validate_positive_sequences
-    raise Exceptions::NegativeSequence if self.class.where(table[:sequence].lteq(0)).exists?
+    raise Exceptions::NegativeSequence, "Internal error caused by concurrency. Please try again" if self.class.where(table[:sequence].lteq(0)).exists?
   end
 end

--- a/app/services/workflow_create_service.rb
+++ b/app/services/workflow_create_service.rb
@@ -14,7 +14,7 @@ class WorkflowCreateService
     begin
       retries ||= 0
       template.workflows.create!(options)
-    rescue ActiveRecord::RecordNotUnique # The auto generated sequence number may be found duplicated due to concurrent issue
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::Deadlocked # The auto generated sequence number may be found duplicated due to concurrent issue
       (retries += 1) < 3 ? retry : raise
     end
   end

--- a/app/services/workflow_delete_service.rb
+++ b/app/services/workflow_delete_service.rb
@@ -9,9 +9,8 @@ class WorkflowDeleteService
     begin
       retries ||= 0
       Workflow.find(workflow_id).destroy!
-    rescue ActiveRecord::RecordNotUnique, Exceptions::NegativeSequence # Failed to update sequence after deletion due to concurrent issue
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::Deadlocked, Exceptions::NegativeSequence # Failed to update sequence after deletion due to concurrent issue
       (retries += 1) < 3 ? retry : raise
     end
   end
-
 end

--- a/app/services/workflow_update_service.rb
+++ b/app/services/workflow_update_service.rb
@@ -16,7 +16,7 @@ class WorkflowUpdateService
     begin
       retries ||= 0
       Workflow.find(workflow_id).update!(options)
-    rescue ActiveRecord::RecordNotUnique, Exceptions::NegativeSequence # Sequence numbers may be found duplicated due to concurrent issue
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::Deadlocked, Exceptions::NegativeSequence # Sequence numbers may be found duplicated due to concurrent issue
       (retries += 1) < 3 ? retry : raise
     end
   end

--- a/config/initializers/custom_exception_mappings.rb
+++ b/config/initializers/custom_exception_mappings.rb
@@ -3,6 +3,7 @@ ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
   "ActiveRecord::RecordNotSaved"               => :bad_request,
   "ActiveRecord::RecordInvalid"                => :bad_request,
   "ActiveRecord::RecordNotUnique"              => :bad_request,
+  "ActiveRecord::Deadlocked"                   => :bad_request,
   "ActionController::ParameterMissing"         => :bad_request,
   "Exceptions::InvalidStateTransitionError"    => :bad_request,
   "Exceptions::NegativeSequence"               => :bad_request,

--- a/spec/controllers/v1.2/workflows_controller_spec.rb
+++ b/spec/controllers/v1.2/workflows_controller_spec.rb
@@ -398,6 +398,19 @@ RSpec.describe Api::V1x2::WorkflowsController, :type => [:request, :v1x2] do
           expect(response).to have_http_status(400)
         end
       end
+
+      context 'when deadlock may be resulted' do
+        before do
+          allow(Workflow).to receive(:find).with(id.to_s).and_return(workflows[0])
+          allow(workflows[0]).to receive(:change_sequences_to_negative).and_raise(ActiveRecord::Deadlocked)
+        end
+
+        it 'returns status code 400' do
+          delete "#{api_version}/workflows/#{id}", :headers => default_headers
+
+          expect(response).to have_http_status(400)
+        end
+      end
     end
 
     context 'approver role when delete' do


### PR DESCRIPTION
Also changes to order-by-id to reduce the possibility of deadlocking.

The problem was reported in QA env, not reproducible by any spec unit tests. Add rescue for deadlocked error in all workflow services that may modify sequence.

https://projects.engineering.redhat.com/browse/SSP-1592