### PR TITLE
Handle a special case when moving last sequence higher

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -80,7 +80,7 @@ class Workflow < ApplicationRecord
 
     if sequence > sequence_was
       sequence_lower(sequence_was, sequence)
-    else
+    elsif sequence < sequence_was
       sequence_higher(sequence, sequence_was)
     end
   end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -78,9 +78,11 @@ class Workflow < ApplicationRecord
     largest = last_sequence
     self.sequence = largest if sequence.nil? || sequence > largest
 
+    return if sequence == sequence_was
+    
     if sequence > sequence_was
       sequence_lower(sequence_was, sequence)
-    elsif sequence < sequence_was
+    else
       sequence_higher(sequence, sequence_was)
     end
   end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -69,6 +69,13 @@ RSpec.describe Workflow, :type => :model do
       expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
     end
 
+    it 'does nothing when attempt to move last sequence further down' do
+      old_ids = Workflow.pluck(:id)
+      Workflow.find(old_ids[4]).update(:sequence => 1000)
+      expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[1], old_ids[2], old_ids[3], old_ids[4]])
+      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
+    end
+
     it 'does not change sequence when only other attributes changed' do
       old_ids = Workflow.pluck(:id)
       Workflow.find(old_ids[1]).update(:name => 'newname')


### PR DESCRIPTION
This is a comer case. Do not adjust neighboring sequences when attempt to move the last sequence higher.

https://projects.engineering.redhat.com/browse/SSP-1650