### PR TITLE
Send workflow deleted event in service class

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -6,7 +6,6 @@ class Workflow < ApplicationRecord
 
   belongs_to :template
   before_destroy :validate_deletable, :prepend => true
-  after_commit :send_deletion_message
   has_many :requests, -> { order(:id => :asc) }, :inverse_of => :workflow, :dependent => :nullify
   has_many :tag_links, :dependent => :destroy, :inverse_of => :workflow
 
@@ -48,10 +47,6 @@ class Workflow < ApplicationRecord
         dependencies[key] << value
       end
     end
-  end
-
-  def send_deletion_message
-    EventService.new(nil).workflow_deleted(id)
   end
 
   def table

--- a/app/services/workflow_delete_service.rb
+++ b/app/services/workflow_delete_service.rb
@@ -9,6 +9,7 @@ class WorkflowDeleteService
     begin
       retries ||= 0
       Workflow.find(workflow_id).destroy!
+      EventService.new(nil).workflow_deleted(workflow_id)
     rescue ActiveRecord::RecordNotUnique, ActiveRecord::Deadlocked, Exceptions::NegativeSequence # Failed to update sequence after deletion due to concurrent issue
       (retries += 1) < 3 ? retry : raise
     end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -133,8 +133,6 @@ RSpec.describe Workflow, :type => :model do
     end
 
     context 'when associated with requests' do
-      let(:event_service) { double('event_service') }
-
       it "is not deletable" do
         allow(workflow).to receive(:deletable?).and_return(false)
 
@@ -149,11 +147,9 @@ RSpec.describe Workflow, :type => :model do
 
       it "is deletable" do
         allow(workflow).to receive(:deletable?).and_return(true)
-        allow(EventService).to receive(:new).and_return(event_service)
 
         request = create(:request, :workflow => workflow, :state => Request::COMPLETED_STATE)
 
-        expect(event_service).to receive(:workflow_deleted)
         expect(TagLink.count).to eq(1)
         workflow.destroy
         request.reload

--- a/spec/services/workflow_delete_service_spec.rb
+++ b/spec/services/workflow_delete_service_spec.rb
@@ -1,10 +1,14 @@
 RSpec.describe WorkflowDeleteService do
   let(:workflows) { create_list(:workflow, 5) }
+  let(:event_service) { double('event_service') }
 
   it 'deletes multiple sequences' do
     Thread.abort_on_exception = true
     trs = workflows.collect do |wf|
       Thread.new do
+        allow(EventService).to receive(:new).and_return(event_service)
+
+        expect(event_service).to receive(:workflow_deleted)
         described_class.new(wf.id).destroy
       end
     end


### PR DESCRIPTION
Fix the bug that we send workflow_deleted event after every commit since it is only needed for destroy operation.

It is more appropriate to send the event in the service class rather than in the model class 