### PR TITLE
Add internal_sequence to workflow

### DIFF
--- a/app/controllers/api/v1x2/workflows_controller.rb
+++ b/app/controllers/api/v1x2/workflows_controller.rb
@@ -68,6 +68,15 @@ module Api
         json_response(workflow)
       end
 
+      def reposition
+        workflow = Workflow.find(params.require(:id))
+        authorize workflow
+
+        SequenceUpdateService.new(params[:id]).move(increment_param)
+
+        head :no_content
+      end
+
       private
 
       def collection(base_query)
@@ -90,6 +99,12 @@ module Api
         raise Exceptions::UserError, "Invalid resource object params: #{resource_object_params}" unless resource_object_params.length.zero? || resource_object_params.length == 3
 
         !!(resource_object_params[:app_name] && resource_object_params[:object_id] && resource_object_params[:object_type])
+      end
+
+      def increment_param
+        raise Exception::UserError, "Cannot have both increment and placement params set" if params[:placement] && params[:increment]
+
+        params[:placement] || params[:increment]
       end
     end
   end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -2,7 +2,7 @@ class Workflow < ApplicationRecord
   include Metadata
   acts_as_tenant(:tenant)
 
-  default_scope { order(:sequence => :asc) }
+  default_scope { order(:internal_sequence => :asc) }
 
   belongs_to :template
   before_destroy :validate_deletable, :prepend => true
@@ -13,7 +13,7 @@ class Workflow < ApplicationRecord
   validates :name, :presence => true, :uniqueness => {:scope => :tenant}
   validates :sequence, :uniqueness => {:scope => :tenant_id}
 
-  before_validation :new_sequence, :on => :create
+  before_validation :assign_new_internal_sequence, :on => :create
   before_validation :adjust_sequences, :on => :update
   after_save        :validate_positive_sequences
   before_destroy    :sequence_lower
@@ -33,6 +33,22 @@ class Workflow < ApplicationRecord
 
   def deletable?
     requests.any? { |request| !request.finished? } ? false : true
+  end
+
+  # move current record up or down relative to other records. delta is an integer
+  def move_internal_sequence(delta)
+    return if delta == 0
+
+    target_sequence = sequence + delta
+    if target_sequence < 1
+      target_sequence = 1
+    else
+      largest = last_sequence
+      target_sequence = largest if target_sequence > largest
+    end
+    self.sequence = target_sequence
+
+    save!
   end
 
   private
@@ -58,6 +74,7 @@ class Workflow < ApplicationRecord
     self.class.arel_table
   end
 
+  # to be removed
   def new_sequence
     throw :abort if sequence && sequence <= 0
 
@@ -69,6 +86,7 @@ class Workflow < ApplicationRecord
     end
   end
 
+  # to be removed
   # no gap between sequences
   def adjust_sequences
     return unless sequence_changed?
@@ -78,44 +96,87 @@ class Workflow < ApplicationRecord
     largest = last_sequence
     self.sequence = largest if sequence.nil? || sequence > largest
 
-    return if sequence == sequence_was
-    
-    if sequence > sequence_was
-      sequence_lower(sequence_was, sequence)
-    else
-      sequence_higher(sequence, sequence_was)
-    end
+    adjust_sequence_and_internal_sequence(sequence - sequence_was) unless sequence == sequence_was
   end
 
+  # to be removed
   # sequences increment between [sequence sequence_was sequence)
   def sequence_higher(startp, endp = nil)
     change_sequences_to_negative(startp, endp, -1)
     change_sequences_to_positive(endp ? -endp - 1 : nil)
   end
 
+  # to be removed
   # sequences decrement between [startp endp]
   def sequence_lower(startp = sequence, endp = nil)
     change_sequences_to_negative(startp, endp, 1)
     change_sequences_to_positive(-startp + 1)
   end
 
+  # to be removed
   def change_sequences_to_negative(startp, endp, delta)
     query = self.class.reorder(:id).where(table[:sequence].gteq(startp))
     query = query.where(table[:sequence].lteq(endp)) if endp
     query.update_all(["sequence = (-sequence + (?))", delta])
   end
 
+  # to be removed
   def change_sequences_to_positive(exceptp)
     query = self.class.reorder(:id).where(table[:sequence].lt(0))
     query = query.where.not(:sequence => exceptp) if exceptp
     query.update_all("sequence = (-sequence)")
   end
 
+  # to be removed
   def last_sequence
     self.class.last&.sequence.to_i
   end
 
+  # to be removed
   def validate_positive_sequences
     raise Exceptions::NegativeSequence, "Internal error caused by concurrency. Please try again" if self.class.where(table[:sequence].lteq(0)).exists?
+  end
+
+  def adjust_sequence_and_internal_sequence(delta)
+    Workflow.transaction do
+      if delta > 0
+        self.internal_sequence = internal_sequence_plus(delta)
+        sequence_lower(sequence - delta, sequence)  # to be removed
+      else
+        self.internal_sequence = internal_sequence_minus(-delta)
+        sequence_higher(sequence, sequence - delta) # to be removed
+      end
+    end
+  end
+
+  def internal_sequence_plus(delta)
+    range = internal_sequence_range(self.class.where(table[:internal_sequence].gt(internal_sequence)), delta)
+    return internal_sequence_extend_from_last if range.empty?
+
+    range.one? ? range.first + 1 : (range.first + range.last) / 2
+  end
+
+  def internal_sequence_minus(delta)
+    range = internal_sequence_range(self.class.reorder('internal_sequence DESC').where(table[:internal_sequence].lt(internal_sequence)), delta)
+    return internal_sequence_before_first if range.empty?
+
+    range.one? ? range.first / 2 : (range.first + range.last) / 2
+  end
+
+  def internal_sequence_range(query, delta)
+    query.select(:internal_sequence).offset(delta - 1).limit(2).collect(&:internal_sequence)
+  end
+
+  def internal_sequence_extend_from_last
+    self.class.select(:internal_sequence).last&.internal_sequence.to_i + 1 # next integer
+  end
+
+  def internal_sequence_before_first
+    self.class.select(:internal_sequence).first.internal_sequence / 2
+  end
+
+  def assign_new_internal_sequence
+    new_sequence # to be removed
+    self.internal_sequence = internal_sequence_extend_from_last
   end
 end

--- a/app/policies/workflow_policy.rb
+++ b/app/policies/workflow_policy.rb
@@ -26,4 +26,8 @@ class WorkflowPolicy < ApplicationPolicy
   def unlink?
     permission_check('unlink')
   end
+
+  def reposition?
+    permission_check('update')
+  end
 end

--- a/app/services/sequence_update_service.rb
+++ b/app/services/sequence_update_service.rb
@@ -1,0 +1,20 @@
+class SequenceUpdateService
+  attr_accessor :workflow_id
+
+  def initialize(workflow_id)
+    self.workflow_id = workflow_id
+  end
+
+  def move(delta)
+    diff = case delta
+           when 'top'
+             -Float::INFINITY
+           when 'bottom'
+             Float::INFINITY
+           else
+             delta.to_i
+           end
+
+    Workflow.find(workflow_id).move_internal_sequence(diff)
+  end
+end

--- a/config/routes/v1x2.rb
+++ b/config/routes/v1x2.rb
@@ -17,6 +17,7 @@ namespace :v1x2, :path => "v1.2" do
 
   post '/workflows/:id/link', :to => "workflows#link", :as => 'link'
   post '/workflows/:id/unlink', :to => "workflows#unlink", :as => 'unlink'
+  post '/workflows/:id/reposition', :to => "workflows#reposition", :as => 'reposition'
 
   resources :templates, :only => %i(index show) do
     resources :workflows, :only => %i(create index)

--- a/db/migrate/20200226115345_delete_always_approve_from_workflows.rb
+++ b/db/migrate/20200226115345_delete_always_approve_from_workflows.rb
@@ -1,4 +1,6 @@
 class DeleteAlwaysApproveFromWorkflows < ActiveRecord::Migration[5.2]
+  class Workflow < ApplicationRecord; end
+
   def up
     always_approve = Workflow.find_by(:name => 'Always approve')
     return unless always_approve

--- a/db/migrate/20200630145352_add_internal_sequences_to_workflow.rb
+++ b/db/migrate/20200630145352_add_internal_sequences_to_workflow.rb
@@ -1,0 +1,15 @@
+class AddInternalSequencesToWorkflow < ActiveRecord::Migration[5.2]
+  def change
+    add_column :workflows, :internal_sequence, :decimal
+
+    add_index  :workflows, [:internal_sequence, :tenant_id], :unique => true
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE workflows SET internal_sequence = sequence;
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_05_141640) do
+ActiveRecord::Schema.define(version: 2020_06_30_145352) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -117,6 +117,8 @@ ActiveRecord::Schema.define(version: 2020_05_05_141640) do
     t.bigint "tenant_id"
     t.jsonb "group_refs", default: [], array: true
     t.integer "sequence"
+    t.decimal "internal_sequence"
+    t.index ["internal_sequence", "tenant_id"], name: "index_workflows_on_internal_sequence_and_tenant_id", unique: true
     t.index ["sequence", "tenant_id"], name: "index_workflows_on_sequence_and_tenant_id", unique: true
     t.index ["template_id"], name: "index_workflows_on_template_id"
     t.index ["tenant_id"], name: "index_workflows_on_tenant_id"

--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "Insights Approval Service API",
         "description": "The API to create and query approval requests",
-        "version": "1.2.1",
+        "version": "1.2.2",
         "contact": {
             "email": "support@redhat.com"
         },
@@ -876,6 +876,46 @@
                     }
                 }
             }
+        },
+        "/workflows/{id}/reposition": {
+            "post": {
+                "tags": [
+                  "Workflow"
+                ],
+                "summary": "Adjust the position of a workflow",
+                "operationId": "reposition",
+                "description": "Adjust the position of a workflow related to others by an offset number",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/id"
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Reposition"
+                            }
+                        }
+                    },
+                    "description": "How many levels should the sequence be brought up or down",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Changed the sequence"
+                    },
+                    "400": {
+                        "$ref": "#/components/schemas/HttpApiErrorCollection"
+                    },
+                    "403": {
+                        "$ref": "#/components/schemas/HttpApiErrorCollection"
+                    },
+                    "404": {
+                        "$ref": "#/components/schemas/HttpApiErrorCollection"
+                    }
+                }
+            }
         }
     },
     "security": [
@@ -1493,7 +1533,7 @@
                         "title": "Metadata",
                         "description": "JSON metadata about the workflow",
                         "readOnly": true,
-                        "example": "{\"user_capabilities\":{\"link\":true,\"show\":true,\"update\":true,\"unlink\":true,\"destroy\":true,\"create\":true},\"object_dependencies\":{\"catalog\":[\"Portfolio\", \"PortfolioItem\"], \"sources\":[\"Source\"]}}"
+                        "example": "{\"user_capabilities\":{\"link\":true,\"show\":true,\"update\":true,\"unlink\":true,\"destroy\":true,\"create\":true,\"reposition\":true},\"object_dependencies\":{\"catalog\":[\"Portfolio\", \"PortfolioItem\"], \"sources\":[\"Source\"]}}"
                     }
                 }
             },
@@ -1516,6 +1556,30 @@
                         "description": "RBAC ID of the group",
                         "format": "uuid",
                         "example": "20560093-369e-412b-9c73-a6799f966447"
+                    }
+                }
+            },
+            "Reposition": {
+                "description": "The desired increment relative to its current position, or placement to top or bottom of the list.",
+                "type": "object",
+                "properties": {
+                    "increment": {
+                        "type": "integer",
+                        "title": "Increment",
+                        "description": "Move the record up (negative) or down (positive) in the list. Do not set it if placement is used",
+                        "example": -2,
+                        "nullable": true
+                    },
+                    "placement": {
+                        "type": "string",
+                        "title": "Placement",
+                        "description": "Place the record to the top or bottom of the list. Do not set it if increment is used",
+                        "enum": [
+                            "bottom",
+                            "top"
+                        ],
+                        "example": "top",
+                        "nullable": true
                     }
                 }
             },

--- a/spec/policies/workflow_policy_spec.rb
+++ b/spec/policies/workflow_policy_spec.rb
@@ -54,12 +54,13 @@ describe WorkflowPolicy do
     end
 
     it 'returns all user capabilities from #user_capabilities' do
-      result = { "create"=>true,
-                 "destroy"=>true,
-                 "link"=>true,
-                 "show"=>true,
-                 "unlink"=>true,
-                 "update"=>true }
+      result = {"create"     => true,
+                "destroy"    => true,
+                "link"       => true,
+                "reposition" => true,
+                "show"       => true,
+                "unlink"     => true,
+                "update"     => true}
 
       expect(subject.user_capabilities).to eq(result)
     end
@@ -72,12 +73,13 @@ describe WorkflowPolicy do
       end
 
       it 'returns false on #destroy in user capabilities' do
-        result = {"create"  => true,
-                  "destroy" => false,
-                  "link"    => true,
-                  "show"    => true,
-                  "unlink"  => true,
-                  "update"  => true}
+        result = {"create"     => true,
+                  "destroy"    => false,
+                  "link"       => true,
+                  "reposition" => true,
+                  "show"       => true,
+                  "unlink"     => true,
+                  "update"     => true}
 
         expect(subject.user_capabilities).to eq(result)
       end
@@ -94,12 +96,13 @@ describe WorkflowPolicy do
     end
 
     it 'returns true from #user_capabilities' do
-      result = { "create"=>false,
-                 "destroy"=>false,
-                 "link"=>false,
-                 "show"=>false,
-                 "unlink"=>false,
-                 "update"=>false }
+      result = {"create"     => false,
+                "destroy"    => false,
+                "link"       => false,
+                "reposition" => false,
+                "show"       => false,
+                "unlink"     => false,
+                "update"     => false}
 
       expect(subject.user_capabilities).to eq(result)
     end
@@ -115,12 +118,13 @@ describe WorkflowPolicy do
     end
 
     it 'returns all user capabilities from #user_capabilities' do
-      result = { "create"=>false,
-                 "destroy"=>false,
-                 "link"=>false,
-                 "show"=>true,
-                 "unlink"=>false,
-                 "update"=>false }
+      result = {"create"     => false,
+                "destroy"    => false,
+                "link"       => false,
+                "reposition" => false,
+                "show"       => true,
+                "unlink"     => false,
+                "update"     => false}
 
       expect(subject.user_capabilities).to eq(result)
     end


### PR DESCRIPTION
Introduce internal_sequence column to workflows table. The column type is numeric type that supports float points with higher precision. The goal is to update only one sequence number while keeping other sequences unchanged and still reach the new desired sorting by sequence.

With this commit we still maintain both internal_sequence and the existing sequence columns and the both sorting are kept synchronized. We will eventually retire old sequence column after UI switches to use internal_sequence.

/workflows/:id/sequence endpoint is added to allow to modify current sequence with an increment. It can be also literally `top` or `bottom`.