### PR TITLE
Remove Dockerfile from .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-Dockerfile
 Gemfile.lock
 .git


### PR DESCRIPTION
Keeping the Dockerfile in the image allows the manifest creation script report the UBI image.