### PR TITLE
Add comment modal

### DIFF
--- a/app/controllers/api/v1x2/stageaction/_modal.html.erb
+++ b/app/controllers/api/v1x2/stageaction/_modal.html.erb
@@ -1,0 +1,101 @@
+<div id="modal_approve" class="modal" style="display: none">
+  <div class="pf-c-backdrop">
+    <div class="pf-l-bullseye">
+      <%= form_tag({:action => 'update', :controller => 'stageaction'}, :method => :patch) do %>
+        <%= hidden_field_tag('approver', Base64.encode64(@approver)) %>
+        <div class="pf-c-modal-box pf-m-sm" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-description">
+          <button class="pf-c-button pf-m-plain close_approve" type="button" aria-label="Close dialog">
+            <i class="fas fa-times" aria-hidden="true"></i>
+          </button>
+          <header class="pf-c-modal-box__header">
+            <h1 class="pf-c-modal-box__title" id="modal-title">Approval request ID <%= @order[:order_id] %></h1>
+          </header>
+          <div class="pf-c-modal-box__body" id="modal-description">
+            <div class="pf-l-grid pf-m-gutter">
+              <div class="pf-c-content">
+                <strong>Comment</strong>
+              </div>
+              <%= text_area_tag(:message, '', :class => "pf-l-grid__item", :style => "height: 100px") %>
+            </div>
+          </div>
+          <footer class="pf-c-modal-box__footer">
+            <div class="pf-c-form__actions">
+              <%= button_tag 'Submit', :class => "pf-c-button pf-m-primary", :type => "submit", :name => :commit, :value => "approve" %>
+              <button class="pf-c-button pf-m-link cancel_btn_approve" type="button">
+                Cancel
+              </button>
+            </div>
+          </footer>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<div id="modal_deny" class="modal" style="display: none">
+  <div class="pf-c-backdrop">
+    <div class="pf-l-bullseye">
+      <%= form_tag({:action => 'update', :controller => 'stageaction'}, :method => :patch) do %>
+        <%= hidden_field_tag('approver', Base64.encode64(@approver)) %>
+        <div class="pf-c-modal-box pf-m-sm" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-description">
+          <button class="pf-c-button pf-m-plain close_deny" type="button" aria-label="Close dialog">
+            <i class="fas fa-times" aria-hidden="true"></i>
+          </button>
+          <header class="pf-c-modal-box__header">
+            <h1 class="pf-c-modal-box__title" id="modal-title">Approval request ID <%= @order[:order_id] %></h1>
+          </header>
+          <div class="pf-c-modal-box__body" id="modal-description">
+            <div class="pf-l-grid pf-m-gutter">
+              <div class="pf-c-content">
+                <strong>Comment</strong>
+              </div>
+              <%= text_area_tag(:message, '', :class => "pf-l-grid__item", :style => "height: 100px", :required => true) %>
+            </div>
+          </div>
+          <footer class="pf-c-modal-box__footer">
+            <div class="pf-c-form__actions">
+              <%= button_tag 'Submit', :class => "pf-c-button pf-m-primary", :type => "submit", :name => :commit, :value => "deny" %>
+              <button class="pf-c-button pf-m-link cancel_btn_deny" type="button">
+                Cancel
+              </button>
+            </div>
+          </footer>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<div id="modal_comment" class="modal" style="display: none">
+  <div class="pf-c-backdrop">
+    <div class="pf-l-bullseye">
+      <%= form_tag({:action => 'update', :controller => 'stageaction'}, :method => :patch) do %>
+        <%= hidden_field_tag('approver', Base64.encode64(@approver)) %>
+        <div class="pf-c-modal-box pf-m-sm" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-description">
+          <button class="pf-c-button pf-m-plain close_comment" type="button" aria-label="Close dialog">
+            <i class="fas fa-times" aria-hidden="true"></i>
+          </button>
+          <header class="pf-c-modal-box__header">
+            <h1 class="pf-c-modal-box__title" id="modal-title">Approval request ID <%= @order[:order_id] %></h1>
+          </header>
+          <div class="pf-c-modal-box__body" id="modal-description">
+            <div class="pf-l-grid pf-m-gutter">
+              <div class="pf-c-content">
+                <strong>Comment</strong>
+              </div>
+              <%= text_area_tag(:message, '', :class => "pf-l-grid__item", :style => "height: 100px", :required => true) %>
+            </div>
+          </div>
+          <footer class="pf-c-modal-box__footer">
+            <div class="pf-c-form__actions">
+              <%= button_tag 'Submit', :class => "pf-c-button pf-m-primary", :type => "submit", :name => :commit, :value => "memo" %>
+              <button class="pf-c-button pf-m-link cancel_btn_comment" type="button">
+                Cancel
+              </button>
+            </div>
+          </footer>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/controllers/api/v1x2/stageaction/show.html.erb
+++ b/app/controllers/api/v1x2/stageaction/show.html.erb
@@ -25,24 +25,89 @@
             </div> 
           </div>        
           <%= render :partial => "request" %>
-          <br>
         </div>
-        <p>
-        <div class="install-title">Comment</div>
-        <%= form_tag({:action => 'update', :controller => 'stageaction'}, :method => :patch) do %>
-          <div class="pf-l-grid pf-m-gutter">
-            <%= text_area_tag(:message, '', :class => "pf-l-grid__item pf-m-12-col-on-xs pf-m-6-col-on-sm pf-m-6-col-on-lg pf-m-6-col-on-xl", :style => "height: 100px") %>
-          </div>
-          <br>
-          <div><strong>Review the information above and approve or deny this request. If you received this request in error, contact your system administrator.</strong></div>
-          <br>
-          <%= hidden_field_tag('approver', Base64.encode64(@approver)) %>
-          <div>
-            <%= button_tag 'Approve', :class => "pf-c-button pf-m-primary", :type => "submit", :name => :commit, :value => "Approve" %>
-            <%= button_tag 'Deny', :class => "pf-c-button pf-m-danger", :type => "submit", :name => :commit, :value => "Deny" %>
-            <%= button_tag 'Comment', :class => "pf-c-button pf-m-secondary", :type => "submit", :name => :commit, :value => "Memo" %>
-          </div>
-        <% end %>
+        <div><strong>Review the information above and approve or deny this request. If you received this request in error, contact your system administrator.</strong></div>
+        <br>
+        <div>
+          <button class="pf-c-button pf-m-primary" type="button" id="btn_approve" >
+            Approve
+          </button>
+          <button class="pf-c-button pf-m-danger" type="button" id="btn_deny" >
+            Deny
+          </button>
+          <button class="pf-c-button pf-m-secondary" type="button" id="btn_comment" >
+            Comment
+          </button>
+        </div>
       </section>
     </section>
+
+<%= render :partial => "modal" %>
 <%= render :partial => "footer" %>
+
+<script>
+// Get the modal
+var modal_approve = document.getElementById("modal_approve");
+var modal_deny = document.getElementById("modal_deny");
+var modal_comment = document.getElementById("modal_comment");
+
+// Get the button that opens the modal
+var btn_approve = document.getElementById("btn_approve");
+var btn_deny = document.getElementById("btn_deny");
+var btn_comment = document.getElementById("btn_comment");
+
+// Get the <span> element that closes the modal
+var span_approve = document.getElementsByClassName("close_approve")[0];
+var span_deny = document.getElementsByClassName("close_deny")[0];
+var span_comment = document.getElementsByClassName("close_comment")[0];
+
+// Get the Cancel button that closes the modal
+var cancel_btn_approve = document.getElementsByClassName("cancel_btn_approve")[0];
+var cancel_btn_deny = document.getElementsByClassName("cancel_btn_deny")[0];
+var cancel_btn_comment = document.getElementsByClassName("cancel_btn_comment")[0];
+
+// When the user clicks the button, open the modal 
+btn_approve.onclick = function() {
+  modal_approve.style.display = "block";
+}
+btn_deny.onclick = function() {
+  modal_deny.style.display = "block";
+}
+btn_comment.onclick = function() {
+  modal_comment.style.display = "block";
+}
+
+// When the user clicks on <span> (x), close the modal
+span_approve.onclick = function() {
+  modal_approve.style.display = "none";
+}
+
+span_deny.onclick = function() {
+  modal_deny.style.display = "none";
+}
+
+span_comment.onclick = function() {
+  modal_comment.style.display = "none";
+}
+
+// When the user clicks the Cancel button, close the modal
+cancel_btn_approve.onclick = function() {
+  modal_approve.style.display = "none";
+}
+
+cancel_btn_deny.onclick = function() {
+  modal_deny.style.display = "none";
+}
+
+cancel_btn_comment.onclick = function() {
+  modal_comment.style.display = "none";
+}
+
+</script>
+
+<style>
+.modal {
+  display: none; /* Hidden by default */
+}
+</style>
+


### PR DESCRIPTION
This PR moves the comment field into a modal, accessed by pressing  "Approve", "Deny", or "Comment" - the same behavior used in the Approval UI.

Jira: https://projects.engineering.redhat.com/browse/SSP-1780

<img width="1269" alt="Screen Shot 2020-08-26 at 3 30 36 PM" src="https://user-images.githubusercontent.com/1287144/91348047-399c6580-e7b1-11ea-81cc-57884dbf957c.png">
<img width="1239" alt="Screen Shot 2020-08-26 at 3 30 27 PM" src="https://user-images.githubusercontent.com/1287144/91348049-3a34fc00-e7b1-11ea-93dc-7a0ade5b06dd.png">
