### PR TITLE
Fix Travis issue with strange encodings in a URL

### DIFF
--- a/spec/open_api_spec.rb
+++ b/spec/open_api_spec.rb
@@ -73,7 +73,19 @@ describe "OpenAPI stuff" do
       it "with a random prefix" do
         expect(ENV["PATH_PREFIX"]).not_to be_nil
         expect(ENV["APP_NAME"]).not_to be_nil
-        expect(api_v1x2_requests_url(:only_path => true)).to eq("/#{ENV["PATH_PREFIX"]}/#{ENV["APP_NAME"]}/v1.2/requests")
+        uri = "/#{ENV["PATH_PREFIX"]}/#{ENV["APP_NAME"]}/v1.2/requests"
+        expect(api_v1x2_requests_url(:only_path => true)).to eq(URI.encode(uri))
+      end
+
+      context "when there is a weird character in the path prefix" do
+        let(:path_prefix) { "" }
+
+        it "escapes the characters properly" do
+          expect(ENV["PATH_PREFIX"]).not_to be_nil
+          expect(ENV["APP_NAME"]).not_to be_nil
+          uri = "/#{ENV["PATH_PREFIX"]}/#{ENV["APP_NAME"]}/v1.2/requests"
+          expect(api_v1x2_requests_url(:only_path => true)).to eq(URI.encode(uri))
+        end
       end
 
       it "with extra slashes" do


### PR DESCRIPTION
I've adjusted the spec that uses the random path prefix creator since it pulls from the dictionary of words in /usr/share/dict/words, and apparently on Travis that dictionary contains words with accents/strange characters. So now we just simply ensure that the resulting request url is encoded as it should be.

I've also added a spec explicitly to show that we handle encodings, even though it's basically identical to the spec above it.

This should fix issues like this one https://travis-ci.org/github/RedHatInsights/approval-api/jobs/722758928