### PR TITLE
Force to resync internal_sequence with sequence through seeding

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -50,6 +50,12 @@ class Workflow < ApplicationRecord
     save!
   end
 
+  # TODO: force synchronizing between two columns. Will be removed when sequence is retired
+  def self.seed
+    Workflow.update_all('internal_sequence = -internal_sequence')
+    Workflow.update_all('internal_sequence = sequence')
+  end
+
   private
 
   def validate_deletable

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -86,6 +86,13 @@ RSpec.describe Workflow, :type => :model do
       expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[2], old_ids[3], old_ids[4]])
       expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4])
     end
+
+    it 'resyncs sequences and internal_sequenes by seed after the order is shuffled' do
+      old_ids = Workflow.pluck(:id)
+      Workflow.find(old_ids[3]).update(:sequence => 1)
+      Workflow.seed
+      expect(Workflow.pluck(:sequence)).to eq(Workflow.pluck(:internal_sequence))
+    end
   end
 
   describe '#move_internal_sequence' do


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1745

When the two sequence columns are out of sync by whatever reason QA is having difficulty to perform tests. This provides a mechanism to bring them back to synchronization.

Temporary. To be removed after sequence is retired