### PR TITLE
Fails request if RBAC error raises during runtime

### DIFF
--- a/app/services/mixins/group_validate_mixin.rb
+++ b/app/services/mixins/group_validate_mixin.rb
@@ -22,8 +22,11 @@ module GroupValidateMixin
 
     begin
       group = ensure_group(request.group_ref, request.context)
-    rescue Exceptions::UserError, RBACApiClient::ApiError, StandardError => e
+    rescue Exceptions::UserError => e
       error_action(request, e.message)
+    rescue => e
+      error_action(request, "Internal error while validating a group. Check log for details.")
+      Rails.logger.error(["Caught an error while validating a group before forwarding the request to PAM.", e.message, *e.backtrace].join($RS))
     end
 
     return false unless group
@@ -71,7 +74,7 @@ module GroupValidateMixin
              end
            rescue Exceptions::UserError
              "#{old_name}(Group does not exist)"
-           rescue StandardError
+           rescue
              old_name
            end
 

--- a/app/services/mixins/group_validate_mixin.rb
+++ b/app/services/mixins/group_validate_mixin.rb
@@ -22,7 +22,7 @@ module GroupValidateMixin
 
     begin
       group = ensure_group(request.group_ref, request.context)
-    rescue Exceptions::UserError => e
+    rescue Exceptions::UserError, RBACApiClient::ApiError, StandardError => e
       error_action(request, e.message)
     end
 

--- a/spec/services/request_update_service_spec.rb
+++ b/spec/services/request_update_service_spec.rb
@@ -100,13 +100,21 @@ RSpec.describe RequestUpdateService do
       end
     end
 
-    it 'calls error_action' do
-      allow(subject).to receive(:ensure_group).and_raise(Exceptions::UserError)
+    context 'when raises exceptions' do
+      shared_examples_for "call_error_action" do |exception|
+        it "calls error_action for #{exception}" do
+          allow(subject).to receive(:ensure_group).and_raise(exception)
 
-      subject.runtime_validate_group(request)
-      request.reload
-      expect(request.actions.count).to eq(1)
-      expect(request.state).to eq(Request::FAILED_STATE)
+          subject.runtime_validate_group(request)
+          request.reload
+          expect(request.actions.count).to eq(1)
+          expect(request.state).to eq(Request::FAILED_STATE)
+        end
+      end
+
+      [Exceptions::UserError, RBACApiClient::ApiError, StandardError].each do |exception|
+        it_behaves_like "call_error_action", exception
+      end
     end
   end
 end


### PR DESCRIPTION
RBAC error during runtime will cause approval request pending forever. This PR rescues such errors and updates request with failed state.

https://projects.engineering.redhat.com/browse/SSP-1814