### PR TITLE
Remove sequence from workflows

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -10,13 +10,9 @@ class Workflow < ApplicationRecord
   has_many :tag_links, :dependent => :destroy, :inverse_of => :workflow
 
   validates :name, :presence => true, :uniqueness => {:scope => :tenant}
-  validates :sequence, :uniqueness => {:scope => :tenant_id}
 
   before_validation :assign_new_internal_sequence, :on => :create
-  before_validation :adjust_sequences, :on => :update
-  after_save        :validate_positive_sequences
-  before_destroy    :sequence_lower
-  after_destroy     :validate_positive_sequences
+  validate :positive_internal_sequence
 
   def external_processing?
     template&.process_setting.present?
@@ -38,22 +34,8 @@ class Workflow < ApplicationRecord
   def move_internal_sequence(delta)
     return if delta == 0
 
-    target_sequence = sequence + delta
-    if target_sequence < 1
-      target_sequence = 1
-    else
-      largest = last_sequence
-      target_sequence = largest if target_sequence > largest
-    end
-    self.sequence = target_sequence
-
-    save!
-  end
-
-  # TODO: force synchronizing between two columns. Will be removed when sequence is retired
-  def self.seed
-    Workflow.update_all('internal_sequence = -internal_sequence')
-    Workflow.update_all('internal_sequence = sequence')
+    new_sequence = delta > 0 ? internal_sequence_plus(delta) : internal_sequence_minus(-delta)
+    update!(:internal_sequence => new_sequence)
   end
 
   private
@@ -75,82 +57,9 @@ class Workflow < ApplicationRecord
     self.class.arel_table
   end
 
-  # to be removed
-  def new_sequence
-    throw :abort if sequence && sequence <= 0
-
-    largest = last_sequence
-    if sequence && sequence < last_sequence
-      sequence_higher(sequence)
-    else
-      self.sequence = largest + 1 # auto_assignment if sequence is nil or too large
-    end
-  end
-
-  # to be removed
-  # no gap between sequences
-  def adjust_sequences
-    return unless sequence_changed?
-
-    throw :abort if sequence && sequence <= 0
-
-    largest = last_sequence
-    self.sequence = largest if sequence.nil? || sequence > largest
-
-    adjust_sequence_and_internal_sequence(sequence - sequence_was) unless sequence == sequence_was
-  end
-
-  # to be removed
-  # sequences increment between [sequence sequence_was sequence)
-  def sequence_higher(startp, endp = nil)
-    change_sequences_to_negative(startp, endp, -1)
-    change_sequences_to_positive(endp ? -endp - 1 : nil)
-  end
-
-  # to be removed
-  # sequences decrement between [startp endp]
-  def sequence_lower(startp = sequence, endp = nil)
-    change_sequences_to_negative(startp, endp, 1)
-    change_sequences_to_positive(-startp + 1)
-  end
-
-  # to be removed
-  def change_sequences_to_negative(startp, endp, delta)
-    query = self.class.reorder(:id).where(table[:sequence].gteq(startp))
-    query = query.where(table[:sequence].lteq(endp)) if endp
-    query.update_all(["sequence = (-sequence + (?))", delta])
-  end
-
-  # to be removed
-  def change_sequences_to_positive(exceptp)
-    query = self.class.reorder(:id).where(table[:sequence].lt(0))
-    query = query.where.not(:sequence => exceptp) if exceptp
-    query.update_all("sequence = (-sequence)")
-  end
-
-  # to be removed
-  def last_sequence
-    self.class.last&.sequence.to_i
-  end
-
-  # to be removed
-  def validate_positive_sequences
-    raise Exceptions::NegativeSequence, "Internal error caused by concurrency. Please try again" if self.class.where(table[:sequence].lteq(0)).exists?
-  end
-
-  def adjust_sequence_and_internal_sequence(delta)
-    Workflow.transaction do
-      if delta > 0
-        self.internal_sequence = internal_sequence_plus(delta)
-        sequence_lower(sequence - delta, sequence)  # to be removed
-      else
-        self.internal_sequence = internal_sequence_minus(-delta)
-        sequence_higher(sequence, sequence - delta) # to be removed
-      end
-    end
-  end
-
   def internal_sequence_plus(delta)
+    return internal_sequence_extend_from_last if delta == Float::INFINITY
+
     range = internal_sequence_range(self.class.where(table[:internal_sequence].gt(internal_sequence)), delta)
     return internal_sequence_extend_from_last if range.empty?
 
@@ -158,6 +67,8 @@ class Workflow < ApplicationRecord
   end
 
   def internal_sequence_minus(delta)
+    return internal_sequence_before_first if delta == Float::INFINITY
+
     range = internal_sequence_range(self.class.reorder('internal_sequence DESC').where(table[:internal_sequence].lt(internal_sequence)), delta)
     return internal_sequence_before_first if range.empty?
 
@@ -177,7 +88,10 @@ class Workflow < ApplicationRecord
   end
 
   def assign_new_internal_sequence
-    new_sequence # to be removed
     self.internal_sequence = internal_sequence_extend_from_last
+  end
+
+  def positive_internal_sequence
+    errors.add(:internal_sequence, 'must be positive') unless internal_sequence > 0
   end
 end

--- a/app/services/workflow_update_service.rb
+++ b/app/services/workflow_update_service.rb
@@ -13,11 +13,6 @@ class WorkflowUpdateService
       options[:group_refs] = validate_approver_groups(options[:group_refs])
     end
 
-    begin
-      retries ||= 0
-      Workflow.find(workflow_id).update!(options)
-    rescue ActiveRecord::RecordNotUnique, ActiveRecord::Deadlocked, Exceptions::NegativeSequence # Sequence numbers may be found duplicated due to concurrent issue
-      (retries += 1) < 3 ? retry : raise
-    end
+    Workflow.find(workflow_id).update!(options)
   end
 end

--- a/db/migrate/20200921142042_remove_sequence_from_workflows.rb
+++ b/db/migrate/20200921142042_remove_sequence_from_workflows.rb
@@ -1,0 +1,6 @@
+class RemoveSequenceFromWorkflows < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :workflows, column: [:sequence, :tenant_id], unique: true
+    remove_column :workflows, :sequence, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_30_145352) do
+ActiveRecord::Schema.define(version: 2020_09_21_142042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -116,10 +116,8 @@ ActiveRecord::Schema.define(version: 2020_06_30_145352) do
     t.datetime "updated_at", null: false
     t.bigint "tenant_id"
     t.jsonb "group_refs", default: [], array: true
-    t.integer "sequence"
     t.decimal "internal_sequence"
     t.index ["internal_sequence", "tenant_id"], name: "index_workflows_on_internal_sequence_and_tenant_id", unique: true
-    t.index ["sequence", "tenant_id"], name: "index_workflows_on_sequence_and_tenant_id", unique: true
     t.index ["template_id"], name: "index_workflows_on_template_id"
     t.index ["tenant_id"], name: "index_workflows_on_tenant_id"
   end

--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -1510,14 +1510,6 @@
                         "nullable": true,
                         "example": "A approval process requires ID department to approve"
                     },
-                    "sequence": {
-                        "type": "integer",
-                        "title": "Sequence",
-                        "description": "an indicator of the execution order for selected workflows",
-                        "minimum": 0,
-                        "exclusiveMinimum": true,
-                        "example": 3
-                    },
                     "group_refs": {
                         "type": "array",
                         "title": "Approval groups",

--- a/spec/controllers/v1.2/workflows_controller_spec.rb
+++ b/spec/controllers/v1.2/workflows_controller_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe Api::V1x2::WorkflowsController, :type => [:request, :v1x2] do
 
   # Test suite for PATCH /workflows/:id
   describe 'PATCH /workflows/:id' do
-    let(:valid_attributes) { {:name => "test", :group_refs => [{'name' => 'n1000', 'uuid' => SecureRandom.uuid}], :sequence => 2} }
+    let(:valid_attributes) { {:name => "test", :group_refs => [{'name' => 'n1000', 'uuid' => SecureRandom.uuid}]} }
     let(:group) { instance_double(Group, :name => 'n1000', :uuid => '1000', :can_approve? => true) }
 
     context 'admin role when item exists' do
@@ -341,13 +341,6 @@ RSpec.describe Api::V1x2::WorkflowsController, :type => [:request, :v1x2] do
         expect(response).to have_http_status(200)
         updated_item = Workflow.find(id)
         expect(updated_item).to have_attributes(valid_attributes)
-      end
-
-      it 'returns status code 400 if sequence is not positive' do
-        valid_attributes[:sequence] = -1
-        patch "#{api_version}/workflows/#{id}", :params => valid_attributes, :headers => default_headers
-
-        expect(response).to have_http_status(400)
       end
     end
 
@@ -399,32 +392,6 @@ RSpec.describe Api::V1x2::WorkflowsController, :type => [:request, :v1x2] do
         delete "#{api_version}/workflows/#{id}", :headers => default_headers
 
         expect(response).to have_http_status(204)
-      end
-
-      context 'when negative sequence may be resulted' do
-        before do
-          allow(Workflow).to receive(:find).with(id.to_s).and_return(workflows[0])
-          allow(workflows[0]).to receive(:validate_positive_sequences).and_raise(Exceptions::NegativeSequence)
-        end
-
-        it 'returns status code 400' do
-          delete "#{api_version}/workflows/#{id}", :headers => default_headers
-
-          expect(response).to have_http_status(400)
-        end
-      end
-
-      context 'when deadlock may be resulted' do
-        before do
-          allow(Workflow).to receive(:find).with(id.to_s).and_return(workflows[0])
-          allow(workflows[0]).to receive(:change_sequences_to_negative).and_raise(ActiveRecord::Deadlocked)
-        end
-
-        it 'returns status code 400' do
-          delete "#{api_version}/workflows/#{id}", :headers => default_headers
-
-          expect(response).to have_http_status(400)
-        end
       end
     end
 

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -8,93 +8,6 @@ RSpec.describe Workflow, :type => :model do
 
   it { should validate_presence_of(:name) }
 
-  describe '#sequence' do
-    around(:each) do |example|
-      ActsAsTenant.with_tenant(tenant) { example.run }
-    end
-
-    before { create_list(:workflow, 5) }
-
-    it 'lists workflows in sequence ascending order' do
-      orders = Workflow.pluck(:sequence)
-      expect(orders).to eq(orders.sort)
-    end
-
-    it 'places newly created workflow to the end of ascending list' do
-      old_last = Workflow.last
-      expect(create(:workflow).sequence).to eq(old_last.sequence + 1)
-    end
-
-    it "auto adjusts newly created workflow's sequence if it is too large" do
-      old_last = Workflow.last
-      expect(create(:workflow, :sequence => 100).sequence).to eq(old_last.sequence + 1)
-    end
-
-    it 'fails the creation if the sequence is not positive' do
-      expect { Workflow.create!(:name => 'any', :sequence => -2) }.to raise_error(ActiveRecord::RecordInvalid)
-    end
-
-    it 'moves a workflow to the top' do
-      old_ids = Workflow.pluck(:id)
-      Workflow.find(old_ids[3]).update(:sequence => 1)
-      expect(Workflow.pluck(:id)).to eq([old_ids[3], old_ids[0], old_ids[1], old_ids[2], old_ids[4]])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
-    end
-
-    it 'moves a worflow to the bottom' do
-      old_ids = Workflow.pluck(:id)
-      Workflow.find(old_ids[3]).update(:sequence => nil)
-      expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[1], old_ids[2], old_ids[4], old_ids[3]])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
-    end
-
-    it 'moves up a workflow sequence' do
-      old_ids = Workflow.pluck(:id)
-      Workflow.find(old_ids[3]).update(:sequence => Workflow.find(old_ids[1]).sequence)
-      expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[3], old_ids[1], old_ids[2], old_ids[4]])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
-    end
-
-    it 'moves down a workflow sequence' do
-      old_ids = Workflow.pluck(:id)
-      Workflow.find(old_ids[1]).update(:sequence => Workflow.find(old_ids[3]).sequence)
-      expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[2], old_ids[3], old_ids[1], old_ids[4]])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
-    end
-
-    it 'does nothing when attempt to move last sequence further down' do
-      old_ids = Workflow.pluck(:id)
-      Workflow.find(old_ids[4]).update(:sequence => 1000)
-      expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[1], old_ids[2], old_ids[3], old_ids[4]])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
-    end
-
-    it 'does not change sequence when only other attributes changed' do
-      old_ids = Workflow.pluck(:id)
-      Workflow.find(old_ids[1]).update(:name => 'newname')
-      expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[1], old_ids[2], old_ids[3], old_ids[4]])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
-    end
-
-    it 'fails to update a 0 sequence' do
-      expect { Workflow.first.update!(:sequence => 0) }.to raise_error(ActiveRecord::RecordInvalid)
-    end
-
-    it 'moves up sequences after a workflow is deleted' do
-      old_ids = Workflow.pluck(:id)
-      Workflow.find(old_ids[1]).destroy
-      expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[2], old_ids[3], old_ids[4]])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4])
-    end
-
-    it 'resyncs sequences and internal_sequenes by seed after the order is shuffled' do
-      old_ids = Workflow.pluck(:id)
-      Workflow.find(old_ids[3]).update(:sequence => 1)
-      Workflow.seed
-      expect(Workflow.pluck(:sequence)).to eq(Workflow.pluck(:internal_sequence))
-    end
-  end
-
   describe '#move_internal_sequence' do
     around(:each) do |example|
       ActsAsTenant.with_tenant(tenant) { example.run }
@@ -108,62 +21,58 @@ RSpec.describe Workflow, :type => :model do
     it 'moves up sequence in range' do
       Workflow.find(old_ids[4]).move_internal_sequence(-2)
       expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[1], old_ids[4], old_ids[2], old_ids[3]])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
     end
 
     it 'moves down sequence in range' do
       Workflow.find(old_ids[1]).move_internal_sequence(2)
       expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[2], old_ids[3], old_ids[1], old_ids[4]])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
     end
 
     it 'moves up to top' do
       Workflow.find(old_ids[2]).move_internal_sequence(-2)
       expect(Workflow.pluck(:id)).to eq([old_ids[2], old_ids[0], old_ids[1], old_ids[3], old_ids[4]])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
     end
 
     it 'moves down to bottom' do
       Workflow.find(old_ids[3]).move_internal_sequence(1)
       expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[1], old_ids[2], old_ids[4], old_ids[3]])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
     end
 
     it 'moves up beyond range' do
       Workflow.find(old_ids[2]).move_internal_sequence(-20)
       expect(Workflow.pluck(:id)).to eq([old_ids[2], old_ids[0], old_ids[1], old_ids[3], old_ids[4]])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
     end
 
     it 'moves down beyond range' do
       Workflow.find(old_ids[3]).move_internal_sequence(20)
       expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[1], old_ids[2], old_ids[4], old_ids[3]])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
     end
 
     it 'moves up to top explicitly' do
       Workflow.find(old_ids[2]).move_internal_sequence(-Float::INFINITY)
       expect(Workflow.pluck(:id)).to eq([old_ids[2], old_ids[0], old_ids[1], old_ids[3], old_ids[4]])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
     end
 
     it 'moves down to bottom explicitly' do
       Workflow.find(old_ids[3]).move_internal_sequence(Float::INFINITY)
       expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[1], old_ids[2], old_ids[4], old_ids[3]])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5])
     end
 
     it 'places the newly created workflow to the end of list' do
       old_ids
       nw = Workflow.create(:name => 'new workflow')
       expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[1], old_ids[2], old_ids[3], old_ids[4], nw.id])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4, 5, 6])
     end
 
     it 'maintains sorting after one workflow is removed' do
       Workflow.find(old_ids[3]).destroy
       expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[1], old_ids[2], old_ids[4]])
-      expect(Workflow.pluck(:sequence)).to eq([1, 2, 3, 4])
+    end
+  end
+
+  describe '#positive_internal_sequence' do
+    it 'validates the internal_sequence must be positive' do
+      expect { workflow.update!(:internal_sequence => -1) }.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Internal sequence must be positive')
     end
   end
 


### PR DESCRIPTION
Sequence has been replaced by internal_sequence, and UI has switched to use internal_sequence. Now it is time to officially remove sequence from workflows.

The original thought was to introduce a new API version. Our current API version is v0.1.2. Since we have made database change, it is impossible to support both v0.1.2 and v0.1.3. And if we simply replace v0.1.2 by v0.1.3, it is impossible to make all other services such as catalog-api and UI to update their client version simultaneously. The best option is to keep the existing version.

https://issues.redhat.com/browse/SSP-1843