### PR TITLE
Fix reposition api return code and required params

### DIFF
--- a/app/controllers/api/v1x2/workflows_controller.rb
+++ b/app/controllers/api/v1x2/workflows_controller.rb
@@ -104,6 +104,8 @@ module Api
       def increment_param
         raise Exception::UserError, "Cannot have both increment and placement params set" if params[:placement] && params[:increment]
 
+        raise Exception::UserError, "Neither increment nor placement parameter is set" unless params[:placement] || params[:increment]
+
         params[:placement] || params[:increment]
       end
     end

--- a/public/doc/openapi-3-v1.2.json
+++ b/public/doc/openapi-3-v1.2.json
@@ -822,7 +822,7 @@
                     "required": true
                 },
                 "responses": {
-                    "200": {
+                    "204": {
                         "description": "Created a link"
                     },
                     "400": {
@@ -862,7 +862,7 @@
                     "required": true
                 },
                 "responses": {
-                    "200": {
+                    "204": {
                         "description": "Broke the link"
                     },
                     "400": {
@@ -902,7 +902,7 @@
                     "required": true
                 },
                 "responses": {
-                    "200": {
+                    "204": {
                         "description": "Changed the sequence"
                     },
                     "400": {

--- a/spec/controllers/v1.2/workflows_controller_spec.rb
+++ b/spec/controllers/v1.2/workflows_controller_spec.rb
@@ -535,6 +535,13 @@ RSpec.describe Api::V1x2::WorkflowsController, :type => [:request, :v1x2] do
       expect(response).to have_http_status(400)
     end
 
+    it 'returns status code 400 when neither placement nor increment is set' do
+      admin_access
+      post "#{api_version}/workflows/#{id}/reposition", :params => {}, :headers => default_headers
+
+      expect(response).to have_http_status(400)
+    end
+
     it 'returns status code 403 for approver' do
       approver_access
       post "#{api_version}/workflows/#{id}/reposition", :params => {:increment => -1}, :headers => default_headers


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-1856
https://issues.redhat.com/browse/SSP-1857

Fix openapi spec for workflow reposition/link/unlink. All of them should return 204.

Raise 400 error if no param is given in the body of reposition api. 