### PR TITLE
Upgrading the insights-api-common gem to 4.1.4 version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 
 gem 'byebug'
 gem 'faraday',             '>= 0.17.0'
-gem 'insights-api-common', '~> 4.0'
+gem 'insights-api-common', '~> 4.1.4'
 gem 'jbuilder',            '~> 2.0'
 gem 'manageiq-loggers',    '~> 0.2'
 gem 'manageiq-messaging',  '~> 0.1'


### PR DESCRIPTION
Upgrading the insights-api-common gem to 4.1.4 version that no longer allows redirects from major versions on a POST.

This PR is based on https://issues.redhat.com/browse/RHCLOUD-9585.