### PR TITLE
Update codeclimate and rubocop yml to use manageiq-style

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,9 +2,9 @@
 version: '2'
 prepare:
   fetch:
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+  - url: https://raw.githubusercontent.com/ManageIQ/manageiq-style/master/.rubocop_base.yml
     path: ".rubocop_base.yml"
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_cc_base.yml
+  - url: https://raw.githubusercontent.com/ManageIQ/manageiq-style/master/.rubocop_cc_base.yml
     path: ".rubocop_cc_base.yml"
 checks:
   argument-count:
@@ -28,4 +28,4 @@ plugins:
   rubocop:
     enabled: true
     config: ".rubocop_cc.yml"
-    channel: "rubocop-0-69"
+    channel: "rubocop-0-82"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,3 @@
 inherit_from:
-- https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+- https://raw.githubusercontent.com/ManageIQ/manageiq-style/master/.rubocop_base.yml
 - .rubocop_local.yml


### PR DESCRIPTION
Just mimicking what we did in catalog-api so that any future PRs for approval-api get updated with the "right" style guide. I imagine this may eventually change to use the RedHatInsights one that Jacob is putting together: https://github.com/RedHatInsights/insights-api-common-rails/pull/210