### PR TITLE
Not to delete so files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY Gemfile $WORKDIR
 RUN echo "gem: --no-document" > ~/.gemrc && \
     gem install bundler --conservative --without development:test && \
     bundle install --jobs 8 --retry 3 && \
-    find $(gem env gemdir)/gems | grep "\.s\?o$" | xargs rm -rvf && \
+#    find $(gem env gemdir)/gems | grep "\.s\?o$" | xargs rm -rvf && \
     rm -rvf $(gem env gemdir)/cache/* && \
     rm -rvf /root/.bundle/cache
 


### PR DESCRIPTION
The old Dockerfile deletes .so files. Bundle install fetches and installs latest nokogiri 1.11.1. When the pod starts it fails immediately with `LoadError: cannot load such file -- nokogiri/nokogiri"`. 

I have tested that the pod starts properly if we leave those files un-removed.

@lindgrenj6 Not sure why the Dockerfile worked until now. I feel it is safe to leave the library files un-removed. Please review. 