### PR TITLE
Do not raise error if signal fails

### DIFF
--- a/app/services/jbpm_process_service.rb
+++ b/app/services/jbpm_process_service.rb
@@ -21,8 +21,8 @@ class JbpmProcessService
       bpm.signal_process_instance(options['container_id'], request.process_ref, options['signal_name'], :body => signal_options(decision))
     end
   rescue => err
-    ActionCreateService.new(request.id).create(:operation => Action::ERROR_OPERATION, :processed_by => 'system', :comments => err.message)
-    raise
+    # Signaling PAM is the last step after the approval has finished. Ignore the error if signal fails
+    Rails.logger.error("Failed to signal PAM with error: #{err.message}")
   end
 
   private

--- a/app/services/request_update_service.rb
+++ b/app/services/request_update_service.rb
@@ -150,7 +150,6 @@ class RequestUpdateService
 
   # complete the external approval process if configured
   def finish_request(decision)
-    return if request_completed?(decision)
     return unless request.process_ref.present? && request.workflow.try(:external_processing?)
 
     template = request.workflow.template

--- a/app/services/request_update_service.rb
+++ b/app/services/request_update_service.rb
@@ -150,7 +150,7 @@ class RequestUpdateService
 
   # complete the external approval process if configured
   def finish_request(decision)
-    return unless request.process_ref.present? && request.workflow.try(:external_processing?)
+    return unless request.process_ref.present? && request.workflow.try(:external_signal?)
 
     template = request.workflow.template
     processor_class = "#{template.signal_setting['processor_type']}_process_service".classify.constantize


### PR DESCRIPTION
This addresses two issues
1. Upon each request finishing we need to send a signal to PAM telling it the process finished. If the signal fails it should not affect our approval request state. We can thus safely ignore the error instead of turning the request's state to failed.
2. `RequestUpdateService#finish_request` skips sending the signal if `request_finished` is true. However this method in the context always returns true so that signal is never triggered. Removing this check will force the signal to be sent. Even if it fails it has no impact to the request itself due to the change in 1.