### PR TITLE
Send group_finished event after update

### DIFF
--- a/spec/services/request_update_service_spec.rb
+++ b/spec/services/request_update_service_spec.rb
@@ -17,9 +17,15 @@ RSpec.describe RequestUpdateService do
 
   context 'state becomes finished' do
     it 'sends request_finished event' do
-      expect(event_service).to receive(:request_completed)
-      expect(event_service).to receive(:approver_group_finished)
-      subject.update(:state => Request::COMPLETED_STATE)
+      expect(event_service).to receive(:request_completed) do
+        request.reload
+        expect(request.decision).to eq(Request::APPROVED_STATUS)
+      end
+      expect(event_service).to receive(:approver_group_finished) do
+        request.reload
+        expect(request.decision).to eq(Request::APPROVED_STATUS)
+      end
+      subject.update(:state => Request::COMPLETED_STATE, :decision => Request::APPROVED_STATUS)
       request.reload
       expect(request.state).to eq(Request::COMPLETED_STATE)
     end


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-1779

The problem with group_finished event was the decision is always `undecided`. The event was sent before the request was saved. Now move the sending after the request has been updated.

Also fixed the issue that request_started event were sent multiple times when multiple groups were involved.