### PR TITLE
simplify .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,6 @@
 Gemfile.lock
-.git
-.bundle
-.vscode
 log
 temp
-.byebug_history
 .*
 v2_key
 


### PR DESCRIPTION
The main purpose is to trigger a build and deploy to cloud