### PR TITLE
Change the autoload_paths to sync with other apps

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ module ServiceApproval
     # Disabling eagerload in production in favor of autoload
     config.autoload_paths += config.eager_load_paths
 
-    config.autoload_paths << Rails.root.join("app", "controllers", "mixins").to_s
+    config.autoload_paths << Rails.root.join("app").to_s
     config.autoload_paths << Rails.root.join('lib').to_s
     config.log_level = (ENV['RAILS_LOG_LEVEL'] || 'debug').downcase.to_sym
     Insights::API::Common::Logging.activate(config)

--- a/config/initializers/controller_test.rb
+++ b/config/initializers/controller_test.rb
@@ -1,0 +1,11 @@
+begin
+  Api::V1x2::ActionsController
+  Api::V1x2::GraphqlController
+  Api::V1x2::RequestsController
+  Api::V1x2::StageactionController
+  Api::V1x2::TemplatesController
+  Api::V1x2::WorkflowsController
+rescue => exception
+  Rails.logger.error("Failed to load rest controllers: #{exception.inspect}")
+  exit(1)
+end


### PR DESCRIPTION
We are seeing occasionally the controllers fail to serve endpoints.
Try to load rest controllers at startup for debugging.